### PR TITLE
Refactor #getServer() to be pre-cached from a CachedServer yaml file

### DIFF
--- a/bukkit/src/main/java/net/william278/huskhomes/api/HuskHomesAPI.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/api/HuskHomesAPI.java
@@ -107,14 +107,14 @@ public class HuskHomesAPI extends BaseHuskHomesAPI {
     }
 
     /**
-     * Get this {@link Server}.
+     * Get the {@link Server}, containing the ID of the server the plugin is running on
      *
-     * @param requester a player; needed to send a plugin message requesting the server if it has not been cached
      * @return the {@link Server}
+     * @since 3.0
      */
     @NotNull
-    public Server getServer(@NotNull OnlineUser requester) {
-        return plugin.getServer(requester);
+    public Server getServer() {
+        return plugin.getPluginServer();
     }
 
 }

--- a/bukkit/src/main/java/net/william278/huskhomes/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/listener/BukkitEventListener.java
@@ -58,7 +58,7 @@ public class BukkitEventListener extends EventListener implements Listener {
         CompletableFuture.runAsync(() -> {
             final BukkitPlayer bukkitPlayer = BukkitPlayer.adapt(player);
             BukkitAdapter.adaptLocation(event.getFrom()).ifPresent(sourceLocation ->
-                    handlePlayerTeleport(bukkitPlayer, new Position(sourceLocation, plugin.getServer(bukkitPlayer))));
+                    handlePlayerTeleport(bukkitPlayer, new Position(sourceLocation, plugin.getPluginServer())));
         });
     }
 
@@ -80,7 +80,7 @@ public class BukkitEventListener extends EventListener implements Listener {
             super.handlePlayerUpdateSpawnPoint(onlineUser, new Position(
                     adaptedLocation.x, adaptedLocation.y, adaptedLocation.z,
                     adaptedLocation.yaw, adaptedLocation.pitch,
-                    adaptedLocation.world, plugin.getServer(onlineUser)));
+                    adaptedLocation.world, plugin.getPluginServer()));
         }));
     }
 

--- a/bukkit/src/main/java/net/william278/huskhomes/player/BukkitPlayer.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/player/BukkitPlayer.java
@@ -65,14 +65,14 @@ public class BukkitPlayer extends OnlineUser {
     public Position getPosition() {
         return new Position(BukkitAdapter.adaptLocation(player.getLocation())
                 .orElseThrow(() -> new HuskHomesException("Failed to get the position of a BukkitPlayer (null)")),
-                BukkitHuskHomes.getInstance().getServer(this));
+                BukkitHuskHomes.getInstance().getPluginServer());
 
     }
 
     @Override
     public Optional<Position> getBedSpawnPosition() {
         return Optional.ofNullable(player.getBedSpawnLocation()).flatMap(BukkitAdapter::adaptLocation)
-                .map(location -> new Position(location, BukkitHuskHomes.getInstance().getServer(this)));
+                .map(location -> new Position(location, BukkitHuskHomes.getInstance().getPluginServer()));
     }
 
     @Override

--- a/common/src/main/java/net/william278/huskhomes/HuskHomes.java
+++ b/common/src/main/java/net/william278/huskhomes/HuskHomes.java
@@ -5,7 +5,7 @@ import net.william278.desertwell.Version;
 import net.william278.huskhomes.command.CommandBase;
 import net.william278.huskhomes.config.Locales;
 import net.william278.huskhomes.config.Settings;
-import net.william278.huskhomes.config.Spawn;
+import net.william278.huskhomes.config.CachedSpawn;
 import net.william278.huskhomes.database.Database;
 import net.william278.huskhomes.event.EventDispatcher;
 import net.william278.huskhomes.hook.EconomyHook;
@@ -165,11 +165,11 @@ public interface HuskHomes {
     List<Migrator> getMigrators();
 
     /**
-     * The {@link Spawn} location of this server
+     * The {@link CachedSpawn} location of this server
      *
-     * @return the {@link Spawn} location data
+     * @return the {@link CachedSpawn} location data
      */
-    Optional<Spawn> getServerSpawn();
+    Optional<CachedSpawn> getServerSpawn();
 
     /**
      * Returns a future returning the latest plugin {@link Version} if the plugin is out-of-date
@@ -188,9 +188,9 @@ public interface HuskHomes {
     }
 
     /**
-     * Update the {@link Spawn} position to a location on the server
+     * Update the {@link CachedSpawn} position to a location on the server
      *
-     * @param location the new {@link Spawn} location
+     * @param location the new {@link CachedSpawn} location
      */
     void setServerSpawn(@NotNull Location location);
 
@@ -270,12 +270,23 @@ public interface HuskHomes {
     CompletableFuture<Optional<Location>> getSafeGroundLocation(@NotNull Location location);
 
     /**
-     * Get the {@link Server} this server is on
+     * Returns the {@link Server} the plugin is on
      *
-     * @return The server
+     * @return The {@link Server} object
+     * @throws HuskHomesException If the server has not been initialized
      */
     @NotNull
-    Server getServer(@NotNull OnlineUser requester);
+    Server getPluginServer() throws HuskHomesException;
+
+    /**
+     * Fetches the name of this server if {@link Server} is {@code null} by querying the proxy
+     *
+     * @param requester The {@link OnlineUser} to carry out the proxy request
+     * @return a future completing when the server has been fetched
+     * @implNote If cross-server mode is disabled, or the server has already been pulled from the server.yml cache file,
+     * the future will return immediately
+     */
+    CompletableFuture<Void> fetchServer(@NotNull OnlineUser requester);
 
     /**
      * Returns a resource read from the plugin resources folder

--- a/common/src/main/java/net/william278/huskhomes/command/SpawnCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/SpawnCommand.java
@@ -26,7 +26,7 @@ public class SpawnCommand extends CommandBase {
         CompletableFuture.runAsync(() -> {
             final Optional<? extends Position> position = (plugin.getSettings().crossServer && plugin.getSettings().globalSpawn
                     ? plugin.getDatabase().getWarp(plugin.getSettings().globalSpawnName).join()
-                    : plugin.getServerSpawn().flatMap(spawn -> spawn.getLocation(plugin.getServer(onlineUser))));
+                    : plugin.getServerSpawn().flatMap(spawn -> spawn.getLocation(plugin.getPluginServer())));
             if (position.isEmpty()) {
                 plugin.getLocales().getLocale("error_spawn_not_set").ifPresent(onlineUser::sendMessage);
                 return;

--- a/common/src/main/java/net/william278/huskhomes/command/TpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/TpCommand.java
@@ -173,7 +173,7 @@ public class TpCommand extends CommandBase implements TabCompletable, ConsoleExe
                         Double.parseDouble(args[3]),
                         0f, 0f,
                         args.length >= 5 ? new World(args[4], UUID.randomUUID()) : plugin.getWorlds().get(0),
-                        args.length == 6 ? new Server(args[5]) : plugin.getServer(playerToTeleport)));
+                        args.length == 6 ? new Server(args[5]) : plugin.getPluginServer()));
             } catch (NumberFormatException e) {
                 plugin.getLoggingAdapter().log(Level.WARNING, "Invalid syntax. Usage: tp <player> <x> <y> <z> [world] [server]");
                 return;

--- a/common/src/main/java/net/william278/huskhomes/config/CachedServer.java
+++ b/common/src/main/java/net/william278/huskhomes/config/CachedServer.java
@@ -1,0 +1,32 @@
+package net.william278.huskhomes.config;
+
+import net.william278.annotaml.YamlFile;
+import net.william278.huskhomes.position.Server;
+import org.jetbrains.annotations.NotNull;
+
+@YamlFile(header = """
+        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ Server ID cache. Must match  ┃
+        ┃ server name in proxy config. ┃
+        ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛""")
+public class CachedServer {
+
+    /**
+     * Name of the server (must match proxy config ID)
+     */
+    public String serverName;
+
+    public CachedServer(@NotNull String serverName) {
+        this.serverName = serverName;
+    }
+
+    @SuppressWarnings("unused")
+    public CachedServer() {
+    }
+
+    @NotNull
+    public Server getServer() {
+        return new Server(serverName);
+    }
+
+}

--- a/common/src/main/java/net/william278/huskhomes/config/CachedSpawn.java
+++ b/common/src/main/java/net/william278/huskhomes/config/CachedSpawn.java
@@ -15,10 +15,10 @@ import java.util.UUID;
  */
 @YamlFile(header = """
         ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-        ┃    Server /spawn location    ┃
+        ┃ Server /spawn location cache ┃
         ┃ Edit in-game using /setspawn ┃
         ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛""")
-public class Spawn {
+public class CachedSpawn {
 
     public double x;
     public double y;
@@ -47,7 +47,7 @@ public class Spawn {
      *
      * @param location The {@link Location} of the spawn
      */
-    public Spawn(@NotNull Location location) {
+    public CachedSpawn(@NotNull Location location) {
         this.x = location.x;
         this.y = location.y;
         this.z = location.z;
@@ -58,6 +58,6 @@ public class Spawn {
     }
 
     @SuppressWarnings("unused")
-    public Spawn() {
+    public CachedSpawn() {
     }
 }

--- a/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
+++ b/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
@@ -38,8 +38,8 @@ public class EventListener {
         // Handle the first player joining the server
         CompletableFuture.runAsync(() -> {
             if (firstUser) {
-                plugin.getServer(onlineUser);
                 firstUser = false;
+                plugin.fetchServer(onlineUser).join();
             }
         }).thenRun(() -> {
             // Ensure the player is present on the database first
@@ -52,7 +52,7 @@ public class EventListener {
                     if (activeTeleport.type == TeleportType.RESPAWN) {
                         final Optional<Position> bedPosition = onlineUser.getBedSpawnPosition();
                         if (bedPosition.isEmpty()) {
-                            plugin.getServerSpawn().flatMap(spawn -> spawn.getLocation(plugin.getServer(onlineUser)))
+                            plugin.getServerSpawn().flatMap(spawn -> spawn.getLocation(plugin.getPluginServer()))
                                     .ifPresent(position -> onlineUser.teleport(position, plugin.getSettings().asynchronousTeleports));
                             onlineUser.sendMinecraftMessage("block.minecraft.spawn.not_valid");
                         } else {
@@ -155,7 +155,7 @@ public class EventListener {
         // Respawn the player cross-server if needed
         if (plugin.getSettings().crossServer && plugin.getSettings().globalRespawning) {
             plugin.getDatabase().getRespawnPosition(onlineUser).thenAccept(position -> position.ifPresent(respawnPosition -> {
-                if (!respawnPosition.server.equals(plugin.getServer(onlineUser))) {
+                if (!respawnPosition.server.equals(plugin.getPluginServer())) {
                     plugin.getTeleportManager().teleport(onlineUser, respawnPosition, TeleportType.RESPAWN).thenAccept(
                             result -> plugin.getTeleportManager().finishTeleport(onlineUser, result));
                 }

--- a/common/src/main/java/net/william278/huskhomes/teleport/TeleportManager.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TeleportManager.java
@@ -354,7 +354,7 @@ public class TeleportManager {
         }
 
         // Teleport player locally, or across server depending on need
-        if (position.server.equals(plugin.getServer(onlineUser))) {
+        if (position.server.equals(plugin.getPluginServer())) {
             return onlineUser.teleport(teleport.target, plugin.getSettings().asynchronousTeleports);
         } else {
             return teleportCrossServer(onlineUser, teleport);


### PR DESCRIPTION
No longer requires a player to get a server; it is instead cached to a `server.yml` file on disk, separate from the main config to still allow admins to create symlinks with that file if they wish. Fixes blocking the main thread with `#join` calls to fetch the server in certain circumstances, which can cause a crash.

After setup for the first time, the server will be cached by the first player joins sending a plugin message.

Closes #199 and #197