### PR TITLE
prevent IllegalArgumentException if y out of range

### DIFF
--- a/bukkit/src/main/java/net/william278/huskhomes/util/BukkitSafetyUtil.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/util/BukkitSafetyUtil.java
@@ -48,6 +48,7 @@ public class BukkitSafetyUtil {
      * @return True if the block is safe, false otherwise
      */
     public static boolean isSafePosition(@NotNull ChunkSnapshot chunkSnapshot, final int chunkX, final int chunkY, final int chunkZ) {
+        if(chunkY<-64||chunkY>320)return false;
         final Material blockType = chunkSnapshot.getBlockType(chunkX, chunkY, chunkZ);
         return switch (blockType) {
             // Special case handling for safe, un-solid blocks


### PR DESCRIPTION
```
[14:48:35 WARN]: Caused by: java.lang.IllegalArgumentException: y out of range (expected -64-320, got -65)
[14:48:35 WARN]:        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:453)
[14:48:35 WARN]:        at org.bukkit.craftbukkit.v1_19_R1.CraftChunk.validateChunkCoordinates(CraftChunk.java:363)
[14:48:35 WARN]:        at org.bukkit.craftbukkit.v1_19_R1.CraftChunkSnapshot.validateChunkCoordinates(CraftChunkSnapshot.java:171)
[14:48:35 WARN]:        at org.bukkit.craftbukkit.v1_19_R1.CraftChunkSnapshot.getBlockType(CraftChunkSnapshot.java:85)
[14:48:35 WARN]:        at HuskHomes-Bukkit-3.0+rev.fde3736.jar//net.william278.huskhomes.util.BukkitSafetyUtil.isSafePosition(BukkitSafetyUtil.java:51)
[14:48:35 WARN]:        at HuskHomes-Bukkit-3.0+rev.fde3736.jar//net.william278.huskhomes.util.BukkitSafetyUtil.findSafeLocation(BukkitSafetyUtil.java:31)
```