### PR TITLE
Port to adventure and MineDown-adventure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ version "$ext.plugin_version-${versionMetadata()}"
 
 ext {
     set 'version', version.toString()
+    set 'adventure_version', adventure_version.toString()
     set 'jedis_version', jedis_version.toString()
     set 'sqlite_driver_version', sqlite_driver_version.toString()
     set 'mysql_driver_version', mysql_driver_version.toString()

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     implementation project(path: ':common')
 
-    implementation 'net.kyori:adventure-platform-bukkit:4.1.2'
     implementation 'org.bstats:bstats-bukkit:3.0.0'
     implementation 'io.papermc:paperlib:1.0.7'
     implementation 'me.lucko:commodore:2.2'
@@ -9,6 +8,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     compileOnly 'org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT'
     compileOnly 'de.themoep:minedown-adventure:1.7.1-SNAPSHOT'
+    compileOnly 'net.kyori:adventure-platform-bukkit:' + adventure_version
     compileOnly 'redis.clients:jedis:' + jedis_version
     compileOnly 'commons-io:commons-io:2.11.0'
     compileOnly 'com.google.guava:guava:31.1-jre'
@@ -19,7 +19,7 @@ dependencies {
 
     testImplementation 'com.github.seeseemelk:MockBukkit-v1.16:1.5.2'
     testImplementation 'de.themoep:minedown-adventure:1.7.1-SNAPSHOT'
-    testImplementation 'net.kyori:adventure-platform-bukkit:4.1.2'
+    testImplementation 'net.kyori:adventure-platform-bukkit:' + adventure_version
     testImplementation 'redis.clients:jedis:' + jedis_version
     testImplementation 'org.xerial:sqlite-jdbc:' + sqlite_driver_version
     testImplementation 'mysql:mysql-connector-java:' + mysql_driver_version
@@ -41,7 +41,6 @@ shadowJar {
     relocate 'net.william278.desertwell', 'net.william278.huskhomes.libraries.desertwell'
     relocate 'org.yaml.snakeyaml', 'net.william278.huskhomes.libraries.snakeyaml'
     relocate 'com.google.gson', 'net.william278.huskhomes.libraries.gson'
-    relocate 'net.kyori.adventure', 'net.william278.huskhomes.libraries.adventure'
 
     relocate 'org.bstats', 'net.william278.huskhomes.libraries.bstats'
     relocate 'io.papermc.lib', 'net.william278.huskhomes.libraries.paperlib'

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -1,23 +1,25 @@
 dependencies {
     implementation project(path: ':common')
 
+    implementation 'net.kyori:adventure-platform-bukkit:4.1.2'
     implementation 'org.bstats:bstats-bukkit:3.0.0'
     implementation 'io.papermc:paperlib:1.0.7'
     implementation 'me.lucko:commodore:2.2'
 
     compileOnly 'org.jetbrains:annotations:23.0.0'
     compileOnly 'org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT'
+    compileOnly 'de.themoep:minedown-adventure:1.7.1-SNAPSHOT'
     compileOnly 'redis.clients:jedis:' + jedis_version
     compileOnly 'commons-io:commons-io:2.11.0'
     compileOnly 'com.google.guava:guava:31.1-jre'
-    compileOnly 'de.themoep:minedown:1.7.1-SNAPSHOT'
     compileOnly 'net.william278:Annotaml:1.0.3'
-    compileOnly 'net.william278:DesertWell:1.0'
+    compileOnly 'net.william278:DesertWell:1.1'
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7.1'
     compileOnly 'us.dynmap:dynmap-api:3.1'
 
     testImplementation 'com.github.seeseemelk:MockBukkit-v1.16:1.5.2'
-    testImplementation 'de.themoep:minedown:1.7.1-SNAPSHOT'
+    testImplementation 'de.themoep:minedown-adventure:1.7.1-SNAPSHOT'
+    testImplementation 'net.kyori:adventure-platform-bukkit:4.1.2'
     testImplementation 'redis.clients:jedis:' + jedis_version
     testImplementation 'org.xerial:sqlite-jdbc:' + sqlite_driver_version
     testImplementation 'mysql:mysql-connector-java:' + mysql_driver_version
@@ -39,6 +41,7 @@ shadowJar {
     relocate 'net.william278.desertwell', 'net.william278.huskhomes.libraries.desertwell'
     relocate 'org.yaml.snakeyaml', 'net.william278.huskhomes.libraries.snakeyaml'
     relocate 'com.google.gson', 'net.william278.huskhomes.libraries.gson'
+    relocate 'net.kyori.adventure', 'net.william278.huskhomes.libraries.adventure'
 
     relocate 'org.bstats', 'net.william278.huskhomes.libraries.bstats'
     relocate 'io.papermc.lib', 'net.william278.huskhomes.libraries.paperlib'

--- a/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
@@ -1,6 +1,7 @@
 package net.william278.huskhomes;
 
 import io.papermc.lib.PaperLib;
+import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.william278.annotaml.Annotaml;
 import net.william278.desertwell.Version;
 import net.william278.huskhomes.command.BukkitCommand;
@@ -84,6 +85,9 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes {
     @Nullable
     private Server server;
 
+    // Adventure audience
+    private BukkitAudiences audiences;
+
     // Instance of the plugin
     private static BukkitHuskHomes instance;
 
@@ -105,6 +109,9 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes {
             // Set the logging and resource reading adapter
             this.logger = new BukkitLogger(getLogger());
             this.resourceReader = new BukkitResourceReader(this);
+
+            // Create adventure audience
+            this.audiences = BukkitAudiences.create(this);
 
             // Detect if an upgrade is needed
             final BukkitUpgradeUtil upgradeData = BukkitUpgradeUtil.detect(this);
@@ -134,7 +141,7 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes {
                 getLoggingAdapter().log(Level.INFO, "Successfully established a connection to the database");
             } else {
                 throw new HuskHomesInitializationException("Failed to establish a connection to the database. " +
-                        "Please check the supplied database credentials in the config file");
+                                                           "Please check the supplied database credentials in the config file");
             }
 
             // Initialize the network messenger if proxy mode is enabled
@@ -196,8 +203,8 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes {
             if (pluginHooks.size() > 0) {
                 pluginHooks.forEach(PluginHook::initialize);
                 getLoggingAdapter().log(Level.INFO, "Registered " + pluginHooks.size() + " plugin hooks: " +
-                        pluginHooks.stream().map(PluginHook::getHookName)
-                                .collect(Collectors.joining(", ")));
+                                                    pluginHooks.stream().map(PluginHook::getHookName)
+                                                            .collect(Collectors.joining(", ")));
             }
 
             // Register events
@@ -227,8 +234,8 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes {
                 if (settings.disabledCommands.stream().anyMatch(disabledCommand -> {
                     final String command = (disabledCommand.startsWith("/") ? disabledCommand.substring(1) : disabledCommand);
                     return command.equalsIgnoreCase(commandType.commandBase.command) ||
-                            Arrays.stream(commandType.commandBase.aliases)
-                                    .anyMatch(alias -> alias.equalsIgnoreCase(command));
+                           Arrays.stream(commandType.commandBase.aliases)
+                                   .anyMatch(alias -> alias.equalsIgnoreCase(command));
                 })) {
                     new BukkitCommand(new DisabledCommand(this), this).register(pluginCommand);
                     return;
@@ -255,7 +262,7 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes {
                 getLatestVersionIfOutdated().thenAccept(newestVersion ->
                         newestVersion.ifPresent(newVersion -> getLoggingAdapter().log(Level.WARNING,
                                 "An update is available for HuskHomes, v" + newVersion
-                                        + " (Currently running v" + getPluginVersion() + ")")));
+                                + " (Currently running v" + getPluginVersion() + ")")));
             }
 
             // Perform automatic upgrade if detected
@@ -297,6 +304,19 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes {
         if (networkMessenger != null) {
             networkMessenger.terminate();
         }
+        if (audiences != null) {
+            audiences.close();
+            audiences = null;
+        }
+    }
+
+    /**
+     * Returns the adventure Bukkit audiences
+     *
+     * @return The adventure Bukkit audiences
+     */
+    public BukkitAudiences getAudiences() {
+        return audiences;
     }
 
     @NotNull

--- a/bukkit/src/main/java/net/william278/huskhomes/command/BukkitCommand.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/command/BukkitCommand.java
@@ -57,7 +57,7 @@ public class BukkitCommand implements CommandExecutor, TabExecutor {
                 consoleExecutable.onConsoleExecute(args);
             } else {
                 plugin.getLocales().getLocale("error_in_game_only").
-                        ifPresent(locale -> sender.spigot().sendMessage(locale.toComponent()));
+                        ifPresent(locale -> plugin.getAudiences().sender(sender).sendMessage(locale.toComponent()));
             }
         }
         return true;

--- a/bukkit/src/main/java/net/william278/huskhomes/player/BukkitPlayer.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/player/BukkitPlayer.java
@@ -1,11 +1,11 @@
 package net.william278.huskhomes.player;
 
-import de.themoep.minedown.MineDown;
-import de.themoep.minedown.MineDownParser;
+import de.themoep.minedown.adventure.MineDown;
+import de.themoep.minedown.adventure.MineDownParser;
 import io.papermc.lib.PaperLib;
-import net.md_5.bungee.api.ChatMessageType;
-import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.TextComponent;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.title.Title;
 import net.md_5.bungee.api.chat.TranslatableComponent;
 import net.william278.huskhomes.BukkitHuskHomes;
 import net.william278.huskhomes.HuskHomesException;
@@ -32,10 +32,12 @@ import java.util.stream.Collectors;
 public class BukkitPlayer extends OnlineUser {
 
     private final Player player;
+    private final Audience audience;
 
     private BukkitPlayer(@NotNull Player player) {
         super(player.getUniqueId(), player.getName());
         this.player = player;
+        this.audience = BukkitHuskHomes.getInstance().getAudiences().player(player);
     }
 
     /**
@@ -96,28 +98,25 @@ public class BukkitPlayer extends OnlineUser {
 
     @Override
     public void sendTitle(@NotNull MineDown mineDown, boolean subTitle) {
-        final String legacyText = TextComponent.toLegacyText(mineDown
+        final Component text = mineDown
                 .disable(MineDownParser.Option.SIMPLE_FORMATTING)
-                .replace().toComponent());
-        player.sendTitle(subTitle ? "" : legacyText, subTitle ? legacyText : "", 10, 70, 20);
+                .replace().toComponent();
+        audience.showTitle(Title.title(subTitle ? Component.empty() : text,
+                subTitle ? text : Component.empty()));
     }
 
     @Override
     public void sendActionBar(@NotNull MineDown mineDown) {
-        player.spigot().sendMessage(ChatMessageType.ACTION_BAR, mineDown
+        audience.sendActionBar(mineDown
                 .disable(MineDownParser.Option.SIMPLE_FORMATTING)
                 .replace().toComponent());
     }
 
     @Override
     public void sendMessage(@NotNull MineDown mineDown) {
-        final BaseComponent[] messageComponents = mineDown
+        audience.sendMessage(mineDown
                 .disable(MineDownParser.Option.SIMPLE_FORMATTING)
-                .replace().toComponent();
-        if (messageComponents.length == 0) {
-            return;
-        }
-        player.spigot().sendMessage(messageComponents);
+                .replace().toComponent());
     }
 
     @Override

--- a/bukkit/src/main/java/net/william278/huskhomes/util/BukkitLogger.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/util/BukkitLogger.java
@@ -1,7 +1,5 @@
 package net.william278.huskhomes.util;
 
-import de.themoep.minedown.MineDown;
-import net.md_5.bungee.api.chat.TextComponent;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.logging.Level;
@@ -22,11 +20,6 @@ public class BukkitLogger extends Logger {
     @Override
     public void log(@NotNull Level level, @NotNull String message) {
         logger.log(level, message);
-    }
-
-    @Override
-    public void log(@NotNull Level level, @NotNull MineDown mineDown) {
-        logger.log(level, TextComponent.toLegacyText(mineDown.toComponent()));
     }
 
     @Override

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -11,6 +11,7 @@ softdepend:
   - BlueMap
   - Plan
 libraries:
+  - 'net.kyori:adventure-platform-bukkit:${adventure_version}'
   - 'redis.clients:jedis:${jedis_version}'
   - 'mysql:mysql-connector-java:${mysql_driver_version}'
   - 'org.xerial:sqlite-jdbc:${sqlite_driver_version}'

--- a/bukkit/src/test/java/net/william278/huskhomes/BukkitPluginTests.java
+++ b/bukkit/src/test/java/net/william278/huskhomes/BukkitPluginTests.java
@@ -3,7 +3,7 @@ package net.william278.huskhomes;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
-import de.themoep.minedown.MineDown;
+import de.themoep.minedown.adventure.MineDown;
 import net.william278.huskhomes.command.BukkitCommandType;
 import net.william278.huskhomes.player.BukkitPlayer;
 import org.junit.jupiter.api.AfterAll;

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
     implementation 'commons-io:commons-io:2.11.0'
-    implementation 'de.themoep:minedown:1.7.1-SNAPSHOT'
+    implementation 'de.themoep:minedown-adventure:1.7.1-SNAPSHOT'
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'net.william278:Annotaml:1.0.3'
-    implementation 'net.william278:PagineDown:1.0.3'
-    implementation 'net.william278:DesertWell:1.0'
+    implementation 'net.william278:PagineDown:1.1'
+    implementation 'net.william278:DesertWell:1.1'
     implementation('com.zaxxer:HikariCP:5.0.1') {
         exclude module: 'slf4j-api'
     }

--- a/common/src/main/java/net/william278/huskhomes/Cache.java
+++ b/common/src/main/java/net/william278/huskhomes/Cache.java
@@ -1,6 +1,6 @@
 package net.william278.huskhomes;
 
-import de.themoep.minedown.MineDown;
+import de.themoep.minedown.adventure.MineDown;
 import net.william278.huskhomes.command.CommandBase;
 import net.william278.huskhomes.config.Locales;
 import net.william278.huskhomes.database.Database;

--- a/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
+++ b/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
@@ -1,6 +1,6 @@
 package net.william278.huskhomes.api;
 
-import de.themoep.minedown.MineDown;
+import de.themoep.minedown.adventure.MineDown;
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.config.Locales;
 import net.william278.huskhomes.player.OnlineUser;

--- a/common/src/main/java/net/william278/huskhomes/command/EditHomeCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/EditHomeCommand.java
@@ -1,6 +1,6 @@
 package net.william278.huskhomes.command;
 
-import de.themoep.minedown.MineDown;
+import de.themoep.minedown.adventure.MineDown;
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.config.Locales;
 import net.william278.huskhomes.config.Settings;

--- a/common/src/main/java/net/william278/huskhomes/command/EditWarpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/EditWarpCommand.java
@@ -1,6 +1,6 @@
 package net.william278.huskhomes.command;
 
-import de.themoep.minedown.MineDown;
+import de.themoep.minedown.adventure.MineDown;
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.player.OnlineUser;
 import net.william278.huskhomes.position.Warp;

--- a/common/src/main/java/net/william278/huskhomes/command/HuskHomesCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/HuskHomesCommand.java
@@ -1,6 +1,6 @@
 package net.william278.huskhomes.command;
 
-import de.themoep.minedown.MineDown;
+import de.themoep.minedown.adventure.MineDown;
 import net.william278.desertwell.AboutMenu;
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.migrator.Migrator;

--- a/common/src/main/java/net/william278/huskhomes/command/TpIgnoreCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/TpIgnoreCommand.java
@@ -1,6 +1,6 @@
 package net.william278.huskhomes.command;
 
-import de.themoep.minedown.MineDown;
+import de.themoep.minedown.adventure.MineDown;
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.player.OnlineUser;
 import net.william278.huskhomes.player.UserData;

--- a/common/src/main/java/net/william278/huskhomes/config/Locales.java
+++ b/common/src/main/java/net/william278/huskhomes/config/Locales.java
@@ -1,6 +1,6 @@
 package net.william278.huskhomes.config;
 
-import de.themoep.minedown.MineDown;
+import de.themoep.minedown.adventure.MineDown;
 import net.william278.annotaml.RootedMap;
 import net.william278.annotaml.YamlFile;
 import org.apache.commons.text.StringEscapeUtils;

--- a/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
+++ b/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
@@ -1,6 +1,6 @@
 package net.william278.huskhomes.listener;
 
-import de.themoep.minedown.MineDown;
+import de.themoep.minedown.adventure.MineDown;
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.config.Settings;
 import net.william278.huskhomes.player.OnlineUser;

--- a/common/src/main/java/net/william278/huskhomes/player/OnlineUser.java
+++ b/common/src/main/java/net/william278/huskhomes/player/OnlineUser.java
@@ -1,6 +1,6 @@
 package net.william278.huskhomes.player;
 
-import de.themoep.minedown.MineDown;
+import de.themoep.minedown.adventure.MineDown;
 import net.william278.huskhomes.position.Location;
 import net.william278.huskhomes.position.Position;
 import net.william278.huskhomes.teleport.TeleportResult;

--- a/common/src/main/java/net/william278/huskhomes/util/Logger.java
+++ b/common/src/main/java/net/william278/huskhomes/util/Logger.java
@@ -1,6 +1,5 @@
 package net.william278.huskhomes.util;
 
-import de.themoep.minedown.MineDown;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.logging.Level;
@@ -15,8 +14,6 @@ public abstract class Logger {
     public abstract void log(@NotNull Level level, @NotNull String message, @NotNull Throwable e);
 
     public abstract void log(@NotNull Level level, @NotNull String message);
-
-    public abstract void log(@NotNull Level level, @NotNull MineDown mineDown);
 
     public abstract void info(@NotNull String message);
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,4 @@ jedis_version=4.2.3
 sqlite_driver_version=3.39.2.0
 mysql_driver_version=8.0.30
 commons_text_version=1.9
+adventure_version = 4.1.2


### PR DESCRIPTION
Uses the bukkit adapter which is downloaded at runtime. The biggest hurdle to migrating to adventure, aside from actually learning it, was the fact that Spigot has a 2MB file size limit on their site for uploading jars, and adventure-bukkit on its own is about 800KB -- which leaves insufficient room. So it's downloaded at runtime, which makes sense as other platform implementations in the future can do the same or use their built-in adventure support.