### PR TITLE
v3.1.x master branch fixes and bulk deletion refactoring

### DIFF
--- a/bukkit/src/main/java/net/william278/huskhomes/event/BukkitEventDispatcher.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/BukkitEventDispatcher.java
@@ -2,6 +2,7 @@ package net.william278.huskhomes.event;
 
 import net.william278.huskhomes.BukkitHuskHomes;
 import net.william278.huskhomes.player.OnlineUser;
+import net.william278.huskhomes.player.User;
 import net.william278.huskhomes.position.Home;
 import net.william278.huskhomes.position.Warp;
 import net.william278.huskhomes.teleport.Teleport;
@@ -100,6 +101,28 @@ public class BukkitEventDispatcher implements EventDispatcher {
         final CompletableFuture<IWarpListEvent> dispatchFuture = new CompletableFuture<>();
         Bukkit.getScheduler().runTask(plugin, () -> {
             final WarpListEvent event = new WarpListEvent(warps, user);
+            Bukkit.getPluginManager().callEvent(event);
+            dispatchFuture.complete(event);
+        });
+        return dispatchFuture;
+    }
+
+    @Override
+    public CompletableFuture<IDeleteAllHomesEvent> dispatchDeleteAllHomesEvent(@NotNull User user) {
+        final CompletableFuture<IDeleteAllHomesEvent> dispatchFuture = new CompletableFuture<>();
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            final DeleteAllHomesEvent event = new DeleteAllHomesEvent(user);
+            Bukkit.getPluginManager().callEvent(event);
+            dispatchFuture.complete(event);
+        });
+        return dispatchFuture;
+    }
+
+    @Override
+    public CompletableFuture<IDeleteAllWarpsEvent> dispatchDeleteAllWarpsEvent() {
+        final CompletableFuture<IDeleteAllWarpsEvent> dispatchFuture = new CompletableFuture<>();
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            final DeleteAllWarpsEvent event = new DeleteAllWarpsEvent();
             Bukkit.getPluginManager().callEvent(event);
             dispatchFuture.complete(event);
         });

--- a/bukkit/src/main/java/net/william278/huskhomes/event/DeleteAllHomesEvent.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/DeleteAllHomesEvent.java
@@ -1,0 +1,47 @@
+package net.william278.huskhomes.event;
+
+import net.william278.huskhomes.player.User;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class DeleteAllHomesEvent extends Event implements IDeleteAllHomesEvent, Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private boolean cancelled;
+
+    @NotNull
+    private final User homeOwner;
+
+    public DeleteAllHomesEvent(@NotNull User homeOwner) {
+        this.homeOwner = homeOwner;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    @SuppressWarnings("unused")
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public @NotNull User getHomeOwner() {
+        return homeOwner;
+    }
+}

--- a/bukkit/src/main/java/net/william278/huskhomes/event/DeleteAllWarpsEvent.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/DeleteAllWarpsEvent.java
@@ -1,0 +1,38 @@
+package net.william278.huskhomes.event;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class DeleteAllWarpsEvent extends Event implements IDeleteAllWarpsEvent, Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private boolean cancelled;
+
+    public DeleteAllWarpsEvent() {
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    @SuppressWarnings("unused")
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+}

--- a/bukkit/src/main/java/net/william278/huskhomes/event/HomeDeleteEvent.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/HomeDeleteEvent.java
@@ -24,6 +24,7 @@ public class HomeDeleteEvent extends Event implements IHomeDeleteEvent, Cancella
         return HANDLER_LIST;
     }
 
+    @SuppressWarnings("unused")
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/bukkit/src/main/java/net/william278/huskhomes/event/HomeListEvent.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/HomeListEvent.java
@@ -31,6 +31,7 @@ public class HomeListEvent extends Event implements IHomeListEvent, Cancellable 
         return HANDLER_LIST;
     }
 
+    @SuppressWarnings("unused")
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/bukkit/src/main/java/net/william278/huskhomes/event/HomeSaveEvent.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/HomeSaveEvent.java
@@ -24,6 +24,7 @@ public class HomeSaveEvent extends Event implements IHomeSaveEvent, Cancellable 
         return HANDLER_LIST;
     }
 
+    @SuppressWarnings("unused")
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/bukkit/src/main/java/net/william278/huskhomes/event/TeleportEvent.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/TeleportEvent.java
@@ -26,6 +26,7 @@ public class TeleportEvent extends Event implements ITeleportEvent {
         return HANDLER_LIST;
     }
 
+    @SuppressWarnings("unused")
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/bukkit/src/main/java/net/william278/huskhomes/event/TeleportWarmupEvent.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/TeleportWarmupEvent.java
@@ -24,6 +24,7 @@ public class TeleportWarmupEvent extends Event implements ITeleportWarmupEvent, 
         return HANDLER_LIST;
     }
 
+    @SuppressWarnings("unused")
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/bukkit/src/main/java/net/william278/huskhomes/event/WarpDeleteEvent.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/WarpDeleteEvent.java
@@ -24,6 +24,7 @@ public class WarpDeleteEvent extends Event implements IWarpDeleteEvent, Cancella
         return HANDLER_LIST;
     }
 
+    @SuppressWarnings("unused")
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/bukkit/src/main/java/net/william278/huskhomes/event/WarpListEvent.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/WarpListEvent.java
@@ -29,6 +29,7 @@ public class WarpListEvent extends Event implements IWarpListEvent, Cancellable 
         return HANDLER_LIST;
     }
 
+    @SuppressWarnings("unused")
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/bukkit/src/main/java/net/william278/huskhomes/event/WarpSaveEvent.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/event/WarpSaveEvent.java
@@ -24,6 +24,7 @@ public class WarpSaveEvent extends Event implements IWarpSaveEvent, Cancellable 
         return HANDLER_LIST;
     }
 
+    @SuppressWarnings("unused")
     public static HandlerList getHandlerList() {
         return HANDLER_LIST;
     }

--- a/bukkit/src/main/java/net/william278/huskhomes/messenger/PluginMessenger.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/messenger/PluginMessenger.java
@@ -71,7 +71,7 @@ public class PluginMessenger extends NetworkMessenger implements PluginMessageLi
 
     @Override
     @SuppressWarnings("UnstableApiUsage")
-    public CompletableFuture<String> getServerName(@NotNull OnlineUser requester) {
+    public CompletableFuture<String> fetchServerName(@NotNull OnlineUser requester) {
         final BukkitHuskHomes plugin = (BukkitHuskHomes) this.plugin;
         final CompletableFuture<String> future = new CompletableFuture<>();
         serverNameRequests.add(future);
@@ -87,7 +87,7 @@ public class PluginMessenger extends NetworkMessenger implements PluginMessageLi
 
     @Override
     @SuppressWarnings("UnstableApiUsage")
-    public CompletableFuture<String[]> getOnlineServers(@NotNull OnlineUser requester) {
+    public CompletableFuture<String[]> fetchOnlineServerList(@NotNull OnlineUser requester) {
         final BukkitHuskHomes plugin = (BukkitHuskHomes) this.plugin;
         final CompletableFuture<String[]> future = new CompletableFuture<>();
         onlineServersRequests.add(future);
@@ -105,7 +105,7 @@ public class PluginMessenger extends NetworkMessenger implements PluginMessageLi
     @SuppressWarnings("UnstableApiUsage")
     public CompletableFuture<Boolean> sendPlayer(@NotNull OnlineUser onlineUser, @NotNull Server server) {
         final BukkitHuskHomes plugin = (BukkitHuskHomes) this.plugin;
-        return getOnlineServers(onlineUser).thenApplyAsync(onlineServers -> {
+        return fetchOnlineServerList(onlineUser).thenApplyAsync(onlineServers -> {
             final Optional<String> targetServer = Arrays.stream(onlineServers)
                     .filter(serverName -> serverName.equals(server.name))
                     .findFirst();
@@ -126,7 +126,7 @@ public class PluginMessenger extends NetworkMessenger implements PluginMessageLi
     }
 
     @Override
-    public CompletableFuture<Message> sendMessage(@NotNull OnlineUser sender, @NotNull Message message) {
+    public CompletableFuture<Message> dispatchMessage(@NotNull OnlineUser sender, @NotNull Message message) {
         final CompletableFuture<Message> repliedMessage = new CompletableFuture<>();
         processingMessages.put(message.uuid, repliedMessage);
         sendPluginMessage((BukkitPlayer) sender, message);

--- a/bukkit/src/main/java/net/william278/huskhomes/messenger/RedisMessenger.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/messenger/RedisMessenger.java
@@ -53,7 +53,7 @@ public class RedisMessenger extends PluginMessenger {
     }
 
     @Override
-    public CompletableFuture<Message> sendMessage(@NotNull OnlineUser sender, @NotNull Message message) {
+    public CompletableFuture<Message> dispatchMessage(@NotNull OnlineUser sender, @NotNull Message message) {
         final CompletableFuture<Message> repliedMessage = new CompletableFuture<>();
         processingMessages.put(message.uuid, repliedMessage);
         redisWorker.sendMessage(message);

--- a/common/src/main/java/net/william278/huskhomes/command/DelHomeCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/DelHomeCommand.java
@@ -3,7 +3,6 @@ package net.william278.huskhomes.command;
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.player.OnlineUser;
 import net.william278.huskhomes.player.User;
-import net.william278.huskhomes.position.Home;
 import net.william278.huskhomes.util.Permission;
 import net.william278.huskhomes.util.RegexUtil;
 import org.jetbrains.annotations.NotNull;
@@ -12,7 +11,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class DelHomeCommand extends CommandBase implements TabCompletable {
@@ -76,7 +74,7 @@ public class DelHomeCommand extends CommandBase implements TabCompletable {
                     plugin.getLocales().getLocale("home_deleted", homeName).ifPresent(deleter::sendMessage);
                     return;
                 }
-                if (homeName.equals("all")) {
+                if (homeName.equalsIgnoreCase("all")) {
                     deleteAllHomes(deleter, homeOwner, delHomeAllConfirm);
                     return;
                 }
@@ -86,7 +84,7 @@ public class DelHomeCommand extends CommandBase implements TabCompletable {
                     plugin.getLocales().getLocale("home_deleted_other", homeOwner.username, homeName).ifPresent(deleter::sendMessage);
                     return;
                 }
-                if (homeName.equals("all")) {
+                if (homeName.equalsIgnoreCase("all")) {
                     deleteAllHomes(deleter, homeOwner, delHomeAllConfirm);
                     return;
                 }
@@ -104,26 +102,21 @@ public class DelHomeCommand extends CommandBase implements TabCompletable {
      */
     private void deleteAllHomes(@NotNull OnlineUser deleter, @NotNull User homeOwner,
                                 final boolean confirm) {
-        plugin.getDatabase().getHomes(homeOwner).thenAccept(homes -> {
-            if (homes.isEmpty()) {
+        if (!confirm) {
+            plugin.getLocales().getLocale("delete_all_homes_confirm")
+                    .ifPresent(deleter::sendMessage);
+            return;
+        }
+
+        plugin.getSavedPositionManager().deleteAllHomes(homeOwner).thenAccept(deleted -> {
+            if (deleted == 0) {
                 plugin.getLocales().getLocale("error_no_warps_set")
                         .ifPresent(deleter::sendMessage);
                 return;
             }
 
-            if (!confirm) {
-                plugin.getLocales().getLocale("delete_all_homes_confirm")
-                        .ifPresent(deleter::sendMessage);
-                return;
-            }
-
-            final List<CompletableFuture<Boolean>> homeDeletionFuture = new ArrayList<>();
-            for (final Home toDelete : homes) {
-                homeDeletionFuture.add(plugin.getSavedPositionManager().deleteHome(homeOwner, toDelete.meta.name));
-            }
-            CompletableFuture.allOf(homeDeletionFuture.toArray(new CompletableFuture[0]))
-                    .thenRun(() -> plugin.getLocales().getLocale("delete_all_homes_success",
-                            Integer.toString(homeDeletionFuture.size())).ifPresent(deleter::sendMessage));
+            plugin.getLocales().getLocale("delete_all_homes_success", Integer.toString(deleted))
+                    .ifPresent(deleter::sendMessage);
         });
     }
 

--- a/common/src/main/java/net/william278/huskhomes/command/DelWarpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/DelWarpCommand.java
@@ -18,6 +18,11 @@ public class DelWarpCommand extends CommandBase implements TabCompletable {
 
     @Override
     public void onExecute(@NotNull OnlineUser onlineUser, @NotNull String[] args) {
+        if (args.length == 0) {
+            plugin.getLocales().getLocale("error_invalid_syntax", "/delwarp <name>")
+                    .ifPresent(onlineUser::sendMessage);
+            return;
+        }
         if (args.length <= 2) {
             final String warpName = args[0];
             final boolean confirm = args.length == 2 && args[1].equalsIgnoreCase("confirm");

--- a/common/src/main/java/net/william278/huskhomes/command/HomeCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/HomeCommand.java
@@ -90,7 +90,7 @@ public class HomeCommand extends CommandBase implements TabCompletable, ConsoleE
             return;
         }
         CompletableFuture.runAsync(() -> {
-            final OnlineUser playerToTeleport = plugin.findPlayer(args[0]).orElse(null);
+            final OnlineUser playerToTeleport = plugin.findOnlinePlayer(args[0]).orElse(null);
             if (playerToTeleport == null) {
                 plugin.getLoggingAdapter().log(Level.WARNING, "Player not found: " + args[0]);
                 return;

--- a/common/src/main/java/net/william278/huskhomes/command/HomeListCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/HomeListCommand.java
@@ -96,16 +96,16 @@ public class HomeListCommand extends CommandBase implements ConsoleExecutable {
                 return;
             }
             final List<Home> homes = plugin.getDatabase().getHomes(userData.get().user()).join();
-            StringJoiner rowJoiner = new StringJoiner("   ");
+            StringJoiner rowJoiner = new StringJoiner("\t");
 
             plugin.getLoggingAdapter().log(Level.INFO, "List of " + userData.get().user().username + "'s "
                     + homes.size() + " homes:");
-            for (int i = 1; i <= homes.size(); i++) {
-                final String home = homes.get(i - 1).meta.name;
+            for (int i = 0; i < homes.size(); i++) {
+                final String home = homes.get(i).meta.name;
                 rowJoiner.add(home.length() < 16 ? home + " ".repeat(16 - home.length()) : home);
-                if (i % 3 == 0) {
+                if ((i + 1) % 3 == 0) {
                     plugin.getLoggingAdapter().log(Level.INFO, rowJoiner.toString());
-                    rowJoiner = new StringJoiner("   ");
+                    rowJoiner = new StringJoiner("\t");
                 }
             }
             plugin.getLoggingAdapter().log(Level.INFO, rowJoiner.toString());

--- a/common/src/main/java/net/william278/huskhomes/command/PublicHomeCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/PublicHomeCommand.java
@@ -102,7 +102,7 @@ public class PublicHomeCommand extends CommandBase implements TabCompletable, Co
             return;
         }
         CompletableFuture.runAsync(() -> {
-            final OnlineUser playerToTeleport = plugin.findPlayer(args[0]).orElse(null);
+            final OnlineUser playerToTeleport = plugin.findOnlinePlayer(args[0]).orElse(null);
             if (playerToTeleport == null) {
                 plugin.getLoggingAdapter().log(Level.WARNING, "Player not found: " + args[0]);
                 return;

--- a/common/src/main/java/net/william278/huskhomes/command/PublicHomeListCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/PublicHomeListCommand.java
@@ -64,18 +64,18 @@ public class PublicHomeListCommand extends CommandBase implements ConsoleExecuta
     public void onConsoleExecute(@NotNull String[] args) {
         CompletableFuture.runAsync(() -> {
             final List<Home> homes = plugin.getDatabase().getPublicHomes().join();
-            StringJoiner rowJoiner = new StringJoiner("   ");
+            StringJoiner rowJoiner = new StringJoiner("\t");
 
             plugin.getLoggingAdapter().log(Level.INFO, "List of " + homes.size() + " public homes:");
-            for (int i = 1; i <= homes.size(); i++) {
-                final String ownerUsername = homes.get(i - 1).owner.username;
-                final String homeName = homes.get(i - 1).meta.name;
+            for (int i = 0; i < homes.size(); i++) {
+                final String ownerUsername = homes.get(i).owner.username;
+                final String homeName = homes.get(i).meta.name;
                 final String home = ownerUsername + "." + homeName;
                 int spacingSize = (16 - ownerUsername.length()) + 17;
                 rowJoiner.add(home.length() < spacingSize ? home + " ".repeat(spacingSize - home.length()) : home);
-                if (i % 3 == 0) {
+                if ((i + 1) % 3 == 0) {
                     plugin.getLoggingAdapter().log(Level.INFO, rowJoiner.toString());
-                    rowJoiner = new StringJoiner("   ");
+                    rowJoiner = new StringJoiner("\t");
                 }
             }
             plugin.getLoggingAdapter().log(Level.INFO, rowJoiner.toString());

--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -31,7 +31,7 @@ public class RtpCommand extends CommandBase implements ConsoleExecutable {
                 plugin.getLocales().getLocale("error_no_permission").ifPresent(onlineUser::sendMessage);
                 return;
             }
-            Optional<OnlineUser> foundUser = plugin.findPlayer(args[0]);
+            final Optional<OnlineUser> foundUser = plugin.findOnlinePlayer(args[0]);
             if (foundUser.isEmpty()) {
                 plugin.getLocales().getLocale("error_player_not_found", args[0])
                         .ifPresent(onlineUser::sendMessage);
@@ -102,7 +102,7 @@ public class RtpCommand extends CommandBase implements ConsoleExecutable {
             plugin.getLoggingAdapter().log(Level.WARNING, "Invalid syntax. Usage: rtp [player]");
             return;
         }
-        final Optional<OnlineUser> foundUser = plugin.findPlayer(args[0]);
+        final Optional<OnlineUser> foundUser = plugin.findOnlinePlayer(args[0]);
         if (foundUser.isEmpty()) {
             plugin.getLoggingAdapter().log(Level.WARNING, "Player not found: " + args[0]);
             return;

--- a/common/src/main/java/net/william278/huskhomes/command/TpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/TpCommand.java
@@ -165,7 +165,7 @@ public class TpCommand extends CommandBase implements TabCompletable, ConsoleExe
             plugin.getLoggingAdapter().log(Level.WARNING, "Invalid syntax. Usage: tp <player> <destination>");
             return;
         }
-        final OnlineUser playerToTeleport = plugin.findPlayer(args[0]).orElse(null);
+        final OnlineUser playerToTeleport = plugin.findOnlinePlayer(args[0]).orElse(null);
         if (playerToTeleport == null) {
             plugin.getLoggingAdapter().log(Level.WARNING, "Player not found: " + args[0]);
             return;

--- a/common/src/main/java/net/william278/huskhomes/command/TpHereCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/TpHereCommand.java
@@ -27,18 +27,27 @@ public class TpHereCommand extends CommandBase implements TabCompletable {
                 return;
             }
             final String targetPlayerName = args[0];
-            Teleport.builder(plugin, onlineUser)
-                    .setTeleporter(targetPlayerName)
-                    .setTarget(onlineUser.getPosition())
-                    .toTeleport()
-                    .thenAccept(teleport -> teleport.execute().thenAccept(result -> {
-                        if (result.successful()) {
-                            result.getTeleporter()
-                                    .flatMap(teleporter -> plugin.getLocales().getLocale("teleporting_other_complete",
-                                            teleporter.username, onlineUser.username))
-                                    .ifPresent(onlineUser::sendMessage);
-                        }
-                    }));
+            plugin.findPlayer(onlineUser, targetPlayerName).thenAccept(teleporterName -> {
+                if (teleporterName.isEmpty()) {
+                    plugin.getLocales().getLocale("error_player_not_found", targetPlayerName)
+                            .ifPresent(onlineUser::sendMessage);
+                    return;
+                }
+
+                Teleport.builder(plugin, onlineUser)
+                        .setTeleporter(teleporterName.get())
+                        .setTarget(onlineUser.getPosition())
+                        .toTeleport()
+                        .thenAccept(teleport -> teleport.execute().thenAccept(result -> {
+                            if (result.successful()) {
+                                result.getTeleporter()
+                                        .flatMap(teleporter -> plugin.getLocales().getLocale("teleporting_other_complete",
+                                                teleporter.username, onlineUser.username))
+                                        .ifPresent(onlineUser::sendMessage);
+                            }
+                        }));
+            });
+
         });
     }
 

--- a/common/src/main/java/net/william278/huskhomes/command/WarpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/WarpCommand.java
@@ -77,7 +77,7 @@ public class WarpCommand extends CommandBase implements TabCompletable, ConsoleE
             plugin.getLoggingAdapter().log(Level.WARNING, "Invalid syntax. Usage: warp <player> <warp>");
             return;
         }
-        final OnlineUser playerToTeleport = plugin.findPlayer(args[0]).orElse(null);
+        final OnlineUser playerToTeleport = plugin.findOnlinePlayer(args[0]).orElse(null);
         if (playerToTeleport == null) {
             plugin.getLoggingAdapter().log(Level.WARNING, "Player not found: " + args[0]);
             return;

--- a/common/src/main/java/net/william278/huskhomes/command/WarpListCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/WarpListCommand.java
@@ -2,13 +2,10 @@ package net.william278.huskhomes.command;
 
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.player.OnlineUser;
-import net.william278.huskhomes.position.Warp;
 import net.william278.huskhomes.util.Permission;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
 import java.util.StringJoiner;
-import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 public class WarpListCommand extends CommandBase implements ConsoleExecutable {
@@ -66,13 +63,13 @@ public class WarpListCommand extends CommandBase implements ConsoleExecutable {
         plugin.getDatabase().getWarps().thenAccept(warps -> {
             plugin.getLoggingAdapter().log(Level.INFO, "List of " + warps.size() + " warps:");
 
-            StringJoiner rowJoiner = new StringJoiner("   ");
-            for (int i = 1; i <= warps.size(); i++) {
-                final String warp = warps.get(i - 1).meta.name;
+            StringJoiner rowJoiner = new StringJoiner("\t");
+            for (int i = 0; i < warps.size(); i++) {
+                final String warp = warps.get(i).meta.name;
                 rowJoiner.add(warp.length() < 16 ? warp + " ".repeat(16 - warp.length()) : warp);
-                if (i % 3 == 0) {
+                if ((i + 1) % 3 == 0) {
                     plugin.getLoggingAdapter().log(Level.INFO, rowJoiner.toString());
-                    rowJoiner = new StringJoiner("   ");
+                    rowJoiner = new StringJoiner("\t");
                 }
             }
             plugin.getLoggingAdapter().log(Level.INFO, rowJoiner.toString());

--- a/common/src/main/java/net/william278/huskhomes/database/Database.java
+++ b/common/src/main/java/net/william278/huskhomes/database/Database.java
@@ -444,12 +444,27 @@ public abstract class Database {
     public abstract CompletableFuture<Void> deleteHome(@NotNull UUID uuid);
 
     /**
+     * Deletes all {@link Home}s of a {@link User} from the home table on the database.
+     *
+     * @param user The {@link User} to delete all homes of
+     * @return A future returning an integer; the number of deleted homes
+     */
+    public abstract CompletableFuture<Integer> deleteAllHomes(@NotNull User user);
+
+    /**
      * Deletes a {@link Warp} by the given unique id from the warp table on the database.
      *
      * @param uuid {@link UUID} of the warp to delete
      * @return A future returning void when complete
      */
     public abstract CompletableFuture<Void> deleteWarp(@NotNull UUID uuid);
+
+    /**
+     * Deletes all {@link Warp}s set on the database table
+     *
+     * @return A future returning an integer; the number of deleted warps
+     */
+    public abstract CompletableFuture<Integer> deleteAllWarps();
 
     /**
      * Close any remaining connection to the database source

--- a/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
@@ -634,6 +634,7 @@ public class MySqlDatabase extends Database {
                                         new Server(resultSet.getString("server_name"))))
                                 .setType(TeleportType.getTeleportType(resultSet.getInt("type"))
                                         .orElse(TeleportType.TELEPORT))
+                                .doUpdateLastPosition(false)
                                 .toTeleport()
                                 .join());
                     }

--- a/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
@@ -1012,6 +1012,32 @@ public class MySqlDatabase extends Database {
     }
 
     @Override
+    public CompletableFuture<Integer> deleteAllHomes(@NotNull User user) {
+        return CompletableFuture.supplyAsync(() -> {
+            try (Connection connection = getConnection()) {
+                try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
+                        DELETE FROM `%positions_table%`
+                        WHERE `%positions_table%`.`id` IN (
+                            SELECT `position_id`
+                            FROM `%saved_positions_table%`
+                            WHERE `%saved_positions_table%`.`id` IN (
+                                SELECT `saved_position_id`
+                                FROM `%homes_table%`
+                                WHERE `owner_uuid`=?
+                            )
+                        );"""))) {
+
+                    statement.setString(1, user.uuid.toString());
+                    return statement.executeUpdate();
+                }
+            } catch (SQLException e) {
+                getLogger().log(Level.SEVERE, "Failed to delete all homes for " + user.username + " from the database", e);
+            }
+            return 0;
+        });
+    }
+
+    @Override
     public CompletableFuture<Void> deleteWarp(@NotNull UUID uuid) {
         return CompletableFuture.runAsync(() -> {
             try (Connection connection = getConnection()) {
@@ -1033,6 +1059,29 @@ public class MySqlDatabase extends Database {
             } catch (SQLException e) {
                 getLogger().log(Level.SEVERE, "Failed to delete a warp from the database", e);
             }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Integer> deleteAllWarps() {
+        return CompletableFuture.supplyAsync(() -> {
+            try (Connection connection = getConnection()) {
+                try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
+                        DELETE FROM `%positions_table%`
+                        WHERE `%positions_table%`.`id` IN (
+                            SELECT `position_id`
+                            FROM `%saved_positions_table%`
+                            WHERE `%saved_positions_table%`.`id` IN (
+                                SELECT `saved_position_id`
+                                FROM `%warps_table%`
+                            )
+                        );"""))) {
+                    return statement.executeUpdate();
+                }
+            } catch (SQLException e) {
+                getLogger().log(Level.SEVERE, "Failed to delete all warps from the database", e);
+            }
+            return 0;
         });
     }
 

--- a/common/src/main/java/net/william278/huskhomes/database/SqLiteDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/SqLiteDatabase.java
@@ -1012,6 +1012,32 @@ public class SqLiteDatabase extends Database {
     }
 
     @Override
+    public CompletableFuture<Integer> deleteAllHomes(@NotNull User user) {
+        return CompletableFuture.supplyAsync(() -> {
+            try (Connection connection = getConnection()) {
+                try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
+                        DELETE FROM `%positions_table%`
+                        WHERE `%positions_table%`.`id` IN (
+                            SELECT `position_id`
+                            FROM `%saved_positions_table%`
+                            WHERE `%saved_positions_table%`.`id` IN (
+                                SELECT `saved_position_id`
+                                FROM `%homes_table%`
+                                WHERE `owner_uuid`=?
+                            )
+                        );"""))) {
+
+                    statement.setString(1, user.uuid.toString());
+                    return statement.executeUpdate();
+                }
+            } catch (SQLException e) {
+                getLogger().log(Level.SEVERE, "Failed to delete all homes for " + user.username + " from the database", e);
+            }
+            return 0;
+        });
+    }
+
+    @Override
     public CompletableFuture<Void> deleteWarp(@NotNull UUID uuid) {
         return CompletableFuture.runAsync(() -> {
             try {
@@ -1033,6 +1059,29 @@ public class SqLiteDatabase extends Database {
             } catch (SQLException e) {
                 getLogger().log(Level.SEVERE, "Failed to delete a warp from the database", e);
             }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Integer> deleteAllWarps() {
+        return CompletableFuture.supplyAsync(() -> {
+            try (Connection connection = getConnection()) {
+                try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
+                        DELETE FROM `%positions_table%`
+                        WHERE `%positions_table%`.`id` IN (
+                            SELECT `position_id`
+                            FROM `%saved_positions_table%`
+                            WHERE `%saved_positions_table%`.`id` IN (
+                                SELECT `saved_position_id`
+                                FROM `%warps_table%`
+                            )
+                        );"""))) {
+                    return statement.executeUpdate();
+                }
+            } catch (SQLException e) {
+                getLogger().log(Level.SEVERE, "Failed to delete all warps from the database", e);
+            }
+            return 0;
         });
     }
 

--- a/common/src/main/java/net/william278/huskhomes/database/SqLiteDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/SqLiteDatabase.java
@@ -630,6 +630,7 @@ public class SqLiteDatabase extends Database {
                                         new Server(resultSet.getString("server_name"))))
                                 .setType(TeleportType.getTeleportType(resultSet.getInt("type"))
                                         .orElse(TeleportType.TELEPORT))
+                                .doUpdateLastPosition(false)
                                 .toTeleport()
                                 .join());
                     }

--- a/common/src/main/java/net/william278/huskhomes/event/EventDispatcher.java
+++ b/common/src/main/java/net/william278/huskhomes/event/EventDispatcher.java
@@ -1,6 +1,7 @@
 package net.william278.huskhomes.event;
 
 import net.william278.huskhomes.player.OnlineUser;
+import net.william278.huskhomes.player.User;
 import net.william278.huskhomes.position.Home;
 import net.william278.huskhomes.position.Warp;
 import net.william278.huskhomes.teleport.Teleport;
@@ -32,4 +33,7 @@ public interface EventDispatcher {
 
     CompletableFuture<IWarpListEvent> dispatchViewWarpListEvent(@NotNull List<Warp> homes, @NotNull OnlineUser user);
 
+    CompletableFuture<IDeleteAllHomesEvent> dispatchDeleteAllHomesEvent(@NotNull User user);
+
+    CompletableFuture<IDeleteAllWarpsEvent> dispatchDeleteAllWarpsEvent();
 }

--- a/common/src/main/java/net/william278/huskhomes/event/IDeleteAllHomesEvent.java
+++ b/common/src/main/java/net/william278/huskhomes/event/IDeleteAllHomesEvent.java
@@ -1,0 +1,19 @@
+package net.william278.huskhomes.event;
+
+import net.william278.huskhomes.player.User;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Representation of an event that fires when all homes are deleted
+ */
+public interface IDeleteAllHomesEvent extends CancellableEvent {
+
+    /**
+     * Get the player whose homes are being deleted
+     *
+     * @return the {@link User} whose homes are being deleted
+     */
+    @NotNull
+    User getHomeOwner();
+
+}

--- a/common/src/main/java/net/william278/huskhomes/event/IDeleteAllWarpsEvent.java
+++ b/common/src/main/java/net/william278/huskhomes/event/IDeleteAllWarpsEvent.java
@@ -1,0 +1,8 @@
+package net.william278.huskhomes.event;
+
+/**
+ * Representation of an event that fires when all warps are deleted
+ */
+public interface IDeleteAllWarpsEvent extends CancellableEvent {
+
+}

--- a/common/src/main/java/net/william278/huskhomes/event/IHomeDeleteEvent.java
+++ b/common/src/main/java/net/william278/huskhomes/event/IHomeDeleteEvent.java
@@ -4,7 +4,7 @@ import net.william278.huskhomes.position.Home;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Representation of an event that fires when a home is deleted
+ * Representation of an event that fires when a single home is deleted
  */
 public interface IHomeDeleteEvent extends CancellableEvent {
 

--- a/common/src/main/java/net/william278/huskhomes/event/IWarpDeleteEvent.java
+++ b/common/src/main/java/net/william278/huskhomes/event/IWarpDeleteEvent.java
@@ -4,7 +4,7 @@ import net.william278.huskhomes.position.Warp;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Representation of an event that fires when a warp is deleted
+ * Representation of an event that fires when a single warp is deleted
  */
 public interface IWarpDeleteEvent extends CancellableEvent {
 

--- a/common/src/main/java/net/william278/huskhomes/hook/BlueMapHook.java
+++ b/common/src/main/java/net/william278/huskhomes/hook/BlueMapHook.java
@@ -6,6 +6,7 @@ import de.bluecolored.bluemap.api.BlueMapWorld;
 import de.bluecolored.bluemap.api.markers.MarkerSet;
 import de.bluecolored.bluemap.api.markers.POIMarker;
 import net.william278.huskhomes.HuskHomes;
+import net.william278.huskhomes.player.User;
 import net.william278.huskhomes.position.Home;
 import net.william278.huskhomes.position.Warp;
 import net.william278.huskhomes.position.World;
@@ -73,7 +74,7 @@ public class BlueMapHook extends MapHook {
                 blueMapAPI -> getBlueMapWorld(blueMapAPI, home.world)).ifPresent(blueMapWorld -> blueMapWorld.getMaps()
                 .forEach(blueMapMap -> blueMapMap.getMarkerSets()
                         .computeIfPresent(blueMapWorld.getId() + ":" + PUBLIC_HOMES_MARKER_SET_ID, (s, markerSet) -> {
-                            markerSet.getMarkers().put(home.uuid.toString(),
+                            markerSet.getMarkers().put(home.owner.uuid + ":" + home.uuid,
                                     POIMarker.toBuilder()
                                             .label("/phome" + home.owner.username + "." + home.meta.name)
                                             .position((int) home.x, (int) home.y, (int) home.z)
@@ -91,9 +92,22 @@ public class BlueMapHook extends MapHook {
         BlueMapAPI.getInstance().flatMap(blueMapAPI -> getBlueMapWorld(blueMapAPI, home.world))
                 .ifPresent(blueMapWorld -> blueMapWorld.getMaps().forEach(blueMapMap -> blueMapMap.getMarkerSets()
                         .computeIfPresent(blueMapWorld.getId() + ":" + PUBLIC_HOMES_MARKER_SET_ID, (s, markerSet) -> {
-                            markerSet.getMarkers().remove(home.uuid.toString());
+                            markerSet.getMarkers().remove(home.owner.uuid + ":" + home.uuid);
                             return markerSet;
                         })));
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> clearHomes(@NotNull User user) {
+        BlueMapAPI.getInstance().ifPresent((BlueMapAPI blueMapAPI) -> blueMapAPI.getWorlds()
+                .forEach(blueMapWorld -> blueMapWorld.getMaps()
+                        .forEach(blueMapMap -> blueMapMap.getMarkerSets()
+                                .computeIfPresent(blueMapWorld.getId() + ":" + PUBLIC_HOMES_MARKER_SET_ID, (s, markerSet) -> {
+                                    markerSet.getMarkers().keySet().removeIf(key -> key.startsWith(user.uuid.toString()));
+                                    return markerSet;
+                                }))));
+
         return CompletableFuture.completedFuture(null);
     }
 
@@ -125,6 +139,19 @@ public class BlueMapHook extends MapHook {
                             markerSet.getMarkers().remove(warp.uuid.toString());
                             return markerSet;
                         })));
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> clearWarps() {
+        BlueMapAPI.getInstance().ifPresent((BlueMapAPI blueMapAPI) -> blueMapAPI.getWorlds()
+                .forEach(blueMapWorld -> blueMapWorld.getMaps()
+                        .forEach(blueMapMap -> blueMapMap.getMarkerSets()
+                                .computeIfPresent(blueMapWorld.getId() + ":" + WARPS_MARKER_SET_ID, (s, markerSet) -> {
+                                    markerSet.getMarkers().clear();
+                                    return markerSet;
+                                }))));
+
         return CompletableFuture.completedFuture(null);
     }
 

--- a/common/src/main/java/net/william278/huskhomes/hook/MapHook.java
+++ b/common/src/main/java/net/william278/huskhomes/hook/MapHook.java
@@ -2,6 +2,7 @@ package net.william278.huskhomes.hook;
 
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.HuskHomesException;
+import net.william278.huskhomes.player.User;
 import net.william278.huskhomes.position.Home;
 import net.william278.huskhomes.position.SavedPosition;
 import net.william278.huskhomes.position.Warp;
@@ -61,6 +62,14 @@ public abstract class MapHook extends PluginHook {
     public abstract CompletableFuture<Void> removeHome(@NotNull Home home);
 
     /**
+     * Clears homes owned by a player from the map
+     *
+     * @param user the player whose homes to clear
+     * @return a {@link CompletableFuture} that completes when the homes have been cleared
+     */
+    public abstract CompletableFuture<Void> clearHomes(@NotNull User user);
+
+    /**
      * Update a warp, adding it to the map if it exists, or updating it on the map if it doesn't
      *
      * @param warp the warp to update
@@ -74,6 +83,13 @@ public abstract class MapHook extends PluginHook {
      * @param warp the warp to remove
      */
     public abstract CompletableFuture<Void> removeWarp(@NotNull Warp warp);
+
+    /**
+     * Clears all warps from the map
+     *
+     * @return a {@link CompletableFuture} that completes when the warps have been cleared
+     */
+    public abstract CompletableFuture<Void> clearWarps();
 
     /**
      * Returns if the position is valid to be set on this server

--- a/common/src/main/java/net/william278/huskhomes/messenger/Message.java
+++ b/common/src/main/java/net/william278/huskhomes/messenger/Message.java
@@ -24,7 +24,7 @@ public class Message {
     public MessageType type;
 
     /**
-     * The kind of message this is - {@link RelayType#MESSAGE} or a {@link RelayType#REPLY} to a message.
+     * Represents the context under which this message is being relayed; an outbound {@link RelayType#MESSAGE} or a {@link RelayType#REPLY} to one.
      */
     @SerializedName("relay_type")
     @NotNull
@@ -91,7 +91,13 @@ public class Message {
      * Identifies the source of the message being relayed - a {@link RelayType#MESSAGE} or a {@link RelayType#REPLY} to a message.
      */
     public enum RelayType {
+        /**
+         * An outbound message to/from a server
+         */
         MESSAGE,
+        /**
+         * A reply to an outbound message
+         */
         REPLY
     }
 

--- a/common/src/main/java/net/william278/huskhomes/request/RequestManager.java
+++ b/common/src/main/java/net/william278/huskhomes/request/RequestManager.java
@@ -12,7 +12,6 @@ import org.jetbrains.annotations.NotNull;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Manages {@link TeleportRequest}s between players
@@ -148,26 +147,25 @@ public class RequestManager {
 
                 // Use the network messenger to send the request
                 request.recipientName = networkedTarget.get();
-                return Optional.ofNullable(plugin.getNetworkMessenger().sendMessage(requester,
-                                new Message(Message.MessageType.TELEPORT_REQUEST,
-                                        requester.username,
-                                        networkedTarget.get(),
-                                        MessagePayload.withTeleportRequest(request),
-                                        Message.RelayType.MESSAGE,
-                                        plugin.getSettings().clusterId))
-                        .orTimeout(3, TimeUnit.SECONDS)
-                        .exceptionally(throwable -> null)
+                return plugin.getNetworkMessenger()
+                        .sendMessage(requester, new Message(Message.MessageType.TELEPORT_REQUEST,
+                                requester.username,
+                                networkedTarget.get(),
+                                MessagePayload.withTeleportRequest(request),
+                                Message.RelayType.MESSAGE,
+                                plugin.getSettings().clusterId))
                         .thenApply(reply -> {
-                            if (reply == null || reply.payload.teleportRequest == null) {
-                                return null;
-                            }
-
-                            // If the message was ignored by the recipient, return false
-                            if (reply.payload.teleportRequest.status == TeleportRequest.RequestStatus.PENDING) {
-                                return request;
+                            if (reply.isPresent()) {
+                                final TeleportRequest result = reply.get().payload.teleportRequest;
+                                if (result == null || result.status == TeleportRequest.RequestStatus.IGNORED) {
+                                    return null;
+                                }
+                                return result;
                             }
                             return null;
-                        }).join());
+                        })
+                        .thenApply(Optional::ofNullable)
+                        .join();
             });
         }
         return CompletableFuture.completedFuture(Optional.empty());
@@ -294,16 +292,15 @@ public class RequestManager {
                             return false;
                         }
 
-                        return plugin.getNetworkMessenger().sendMessage(recipient,
-                                        new Message(Message.MessageType.TELEPORT_REQUEST_RESPONSE,
-                                                recipient.username,
-                                                networkedTarget.get(),
-                                                MessagePayload.withTeleportRequest(request),
-                                                Message.RelayType.MESSAGE,
-                                                plugin.getSettings().clusterId))
-                                .thenApply(reply -> true)
-                                .orTimeout(3, TimeUnit.SECONDS)
-                                .exceptionally(throwable -> false).join();
+                        return plugin.getNetworkMessenger()
+                                .sendMessage(recipient, new Message(Message.MessageType.TELEPORT_REQUEST_RESPONSE,
+                                        recipient.username,
+                                        networkedTarget.get(),
+                                        MessagePayload.withTeleportRequest(request),
+                                        Message.RelayType.MESSAGE,
+                                        plugin.getSettings().clusterId))
+                                .thenApply(Optional::isPresent)
+                                .join();
                     })
                     .thenAccept(online -> {
                         if (!online) {

--- a/common/src/main/java/net/william278/huskhomes/request/RequestManager.java
+++ b/common/src/main/java/net/william278/huskhomes/request/RequestManager.java
@@ -128,7 +128,7 @@ public class RequestManager {
                                                                             @NotNull TeleportRequest.RequestType requestType) {
         final TeleportRequest request = new TeleportRequest(requester, requestType,
                 Instant.now().getEpochSecond() + plugin.getSettings().teleportRequestExpiryTime);
-        final Optional<OnlineUser> localTarget = plugin.findPlayer(targetUser);
+        final Optional<OnlineUser> localTarget = plugin.findOnlinePlayer(targetUser);
         if (localTarget.isPresent()) {
             if (localTarget.get().uuid.equals(requester.uuid)) {
                 return CompletableFuture.completedFuture(Optional.empty());
@@ -278,7 +278,7 @@ public class RequestManager {
         request.status = accepted ? TeleportRequest.RequestStatus.ACCEPTED : TeleportRequest.RequestStatus.DECLINED;
 
         // Send request response to the sender
-        final Optional<OnlineUser> localRequester = plugin.findPlayer(request.requesterName);
+        final Optional<OnlineUser> localRequester = plugin.findOnlinePlayer(request.requesterName);
         if (localRequester.isPresent()) {
             handleLocalRequestResponse(localRequester.get(), request);
         } else if (plugin.getSettings().crossServer) {

--- a/common/src/main/java/net/william278/huskhomes/teleport/Teleport.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/Teleport.java
@@ -223,13 +223,14 @@ public class Teleport {
                                 MessagePayload.withPosition(target),
                                 Message.RelayType.MESSAGE,
                                 plugin.getSettings().clusterId))
-                .orTimeout(3, TimeUnit.SECONDS)
-                .exceptionally(throwable -> null)
                 .thenApply(result -> {
-                    if (result == null || result.payload.resultState == null) {
-                        return TeleportResult.FAILED_TELEPORTER_NOT_RESOLVED;
+                    if (result.isPresent()) {
+                        final Message reply = result.get();
+                        if (reply.payload.resultState != null) {
+                            return reply.payload.resultState;
+                        }
                     }
-                    return result.payload.resultState;
+                    return TeleportResult.FAILED_TELEPORTER_NOT_RESOLVED;
                 });
     }
 

--- a/common/src/main/java/net/william278/huskhomes/teleport/Teleport.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/Teleport.java
@@ -61,17 +61,23 @@ public class Teleport {
     public final Set<Settings.EconomyAction> economyActions;
 
     /**
+     * Whether to update the {@link #teleporter teleporter}'s last position (i.e. their {@code /back} position)
+     */
+    public final boolean updateLastPosition;
+
+    /**
      * <b>Internal</b> - use TeleportBuilder to instantiate a teleport
      */
     protected Teleport(@Nullable User teleporter, @NotNull OnlineUser executor, @Nullable Position target,
                        @NotNull TeleportType type, @NotNull Set<Settings.EconomyAction> economyActions,
-                       @NotNull HuskHomes plugin) {
+                       final boolean updateLastPosition, @NotNull HuskHomes plugin) {
         this.teleporter = teleporter;
         this.executor = executor;
         this.target = target;
         this.type = type;
         this.economyActions = economyActions;
         this.plugin = plugin;
+        this.updateLastPosition = updateLastPosition;
     }
 
     /**
@@ -167,7 +173,7 @@ public class Teleport {
 
         // Dispatch the teleport event and update the player's last position
         plugin.getEventDispatcher().dispatchTeleportEvent(this);
-        if (!plugin.getSettings().backCommandSaveOnTeleportEvent && type == TeleportType.TELEPORT) {
+        if (updateLastPosition && !plugin.getSettings().backCommandSaveOnTeleportEvent && type == TeleportType.TELEPORT) {
             plugin.getDatabase().setLastPosition(teleporter, teleporter.getPosition());
         }
 

--- a/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
@@ -12,7 +12,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 /**
@@ -237,7 +236,7 @@ public class TeleportBuilder {
         if (plugin.getSettings().crossServer) {
             return plugin.getNetworkMessenger()
                     .findPlayer(executor, playerName)
-                    .thenApply(foundPlayer -> {
+                    .thenApplyAsync(foundPlayer -> {
                         if (foundPlayer.isEmpty()) {
                             return Optional.empty();
                         }
@@ -245,9 +244,7 @@ public class TeleportBuilder {
                                 .sendMessage(executor, new Message(Message.MessageType.POSITION_REQUEST,
                                         executor.username, playerName, MessagePayload.empty(),
                                         Message.RelayType.MESSAGE, plugin.getSettings().clusterId))
-                                .orTimeout(3, TimeUnit.SECONDS)
-                                .exceptionally(throwable -> null)
-                                .thenApply(reply -> Optional.ofNullable(reply == null ? null : reply.payload.position)).join();
+                                .thenApply(reply -> reply.map(message -> message.payload.position)).join();
                     });
         }
         return CompletableFuture.supplyAsync(Optional::empty);

--- a/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
@@ -226,12 +226,12 @@ public class TeleportBuilder {
                             return Optional.empty();
                         }
                         return plugin.getNetworkMessenger()
-                                .sendMessage(executor, new Message(Message.MessageType.POSITION_REQUEST, executor.username,
-                                        playerName, MessagePayload.empty(), Message.RelayType.MESSAGE,
-                                        plugin.getSettings().clusterId))
+                                .sendMessage(executor, new Message(Message.MessageType.POSITION_REQUEST,
+                                        executor.username, playerName, MessagePayload.empty(),
+                                        Message.RelayType.MESSAGE, plugin.getSettings().clusterId))
                                 .orTimeout(3, TimeUnit.SECONDS)
                                 .exceptionally(throwable -> null)
-                                .thenApply(reply -> Optional.ofNullable(reply.payload.position)).join();
+                                .thenApply(reply -> Optional.ofNullable(reply == null ? null : reply.payload.position)).join();
                     });
         }
         return CompletableFuture.supplyAsync(Optional::empty);

--- a/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
@@ -57,6 +57,11 @@ public class TeleportBuilder {
      */
     private TeleportType type = TeleportType.TELEPORT;
 
+    /**
+     * Whether this teleport should update the user's last position (i.e. their {@code /back} position)
+     */
+    private boolean updateLastPosition = true;
+
     protected TeleportBuilder(@NotNull HuskHomes plugin, @NotNull OnlineUser executor) {
         this.plugin = plugin;
         this.executor = executor;
@@ -169,6 +174,17 @@ public class TeleportBuilder {
     }
 
     /**
+     * Set whether this teleport should update the user's last position (i.e. their {@code /back} position)
+     *
+     * @param updateLastPosition Whether this teleport should update the user's last position
+     * @return The {@link TeleportBuilder} instance
+     */
+    public TeleportBuilder doUpdateLastPosition(boolean updateLastPosition) {
+        this.updateLastPosition = updateLastPosition;
+        return this;
+    }
+
+    /**
      * Resolve the teleporter and target, and construct as an instantly-completing {@link Teleport}
      *
      * @return The constructed {@link Teleport}
@@ -178,7 +194,7 @@ public class TeleportBuilder {
             final User teleporter = this.teleporter.join();
             final Position target = this.target.join();
 
-            return new Teleport(teleporter, executor, target, type, economyActions, plugin);
+            return new Teleport(teleporter, executor, target, type, economyActions, updateLastPosition, plugin);
         }).exceptionally(e -> {
             plugin.getLoggingAdapter().log(Level.SEVERE, "Failed to create teleport", e);
             return null;
@@ -200,7 +216,7 @@ public class TeleportBuilder {
                 throw new IllegalStateException("Timed teleports can only be executed for local users");
             }
 
-            return new TimedTeleport(onlineUser, executor, target, type, warmupTime, economyActions, plugin);
+            return new TimedTeleport(onlineUser, executor, target, type, warmupTime, economyActions, updateLastPosition, plugin);
         }).exceptionally(e -> {
             plugin.getLoggingAdapter().log(Level.SEVERE, "Failed to create timed teleport", e);
             return null;

--- a/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TeleportBuilder.java
@@ -87,7 +87,7 @@ public class TeleportBuilder {
      */
     public TeleportBuilder setTeleporter(@NotNull String teleporterUsername) {
         this.teleporter = CompletableFuture.supplyAsync(() -> plugin
-                .findPlayer(teleporterUsername)
+                .findOnlinePlayer(teleporterUsername)
                 .map(onlineUser -> (User) onlineUser)
                 .or(() -> {
                     if (plugin.getSettings().crossServer) {
@@ -229,7 +229,7 @@ public class TeleportBuilder {
      * @return future optionally supplying the player's position, if the player could be found
      */
     private CompletableFuture<Optional<Position>> getPlayerPosition(@NotNull String playerName) {
-        final Optional<OnlineUser> localPlayer = plugin.findPlayer(playerName);
+        final Optional<OnlineUser> localPlayer = plugin.findOnlinePlayer(playerName);
         if (localPlayer.isPresent()) {
             return CompletableFuture.supplyAsync(() -> Optional.of(localPlayer.get().getPosition()));
         }

--- a/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
@@ -30,7 +30,7 @@ public class TimedTeleport extends Teleport {
         this.plugin = plugin;
         this.startLocation = teleporter.getPosition();
         this.startHealth = teleporter.getHealth();
-        this.timeLeft = warmupTime;
+        this.timeLeft = Math.max(warmupTime, 0);
         this.teleporter = teleporter;
     }
 
@@ -47,15 +47,15 @@ public class TimedTeleport extends Teleport {
                     .thenApply(resultState -> CompletedTeleport.from(resultState, this));
         }
 
+        // Check if the teleporter can bypass warmup
+        if (timeLeft == 0 || teleporter.hasPermission(Permission.BYPASS_TELEPORT_WARMUP.node)) {
+            return super.execute();
+        }
+
         // Check if the teleporter is already warming up to teleport
         if (plugin.getCache().currentlyOnWarmup.contains(teleporter.uuid)) {
             return CompletableFuture.completedFuture(TeleportResult.FAILED_ALREADY_TELEPORTING)
                     .thenApply(resultState -> CompletedTeleport.from(resultState, this));
-        }
-
-        // Check if the teleporter can bypass warmup
-        if (teleporter.hasPermission(Permission.BYPASS_TELEPORT_WARMUP.node)) {
-            return super.execute();
         }
 
         // Check economy actions

--- a/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/TimedTeleport.java
@@ -25,8 +25,8 @@ public class TimedTeleport extends Teleport {
 
     protected TimedTeleport(@NotNull OnlineUser teleporter, @NotNull OnlineUser executor, @NotNull Position target,
                             @NotNull TeleportType type, int warmupTime, @NotNull Set<Settings.EconomyAction> economyActions,
-                            @NotNull HuskHomes plugin) {
-        super(teleporter, executor, target, type, economyActions, plugin);
+                            final boolean updateLastPosition, @NotNull HuskHomes plugin) {
+        super(teleporter, executor, target, type, economyActions, updateLastPosition, plugin);
         this.plugin = plugin;
         this.startLocation = teleporter.getPosition();
         this.startHealth = teleporter.getHealth();

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.daemon=true
 javaVersion=16
 
-plugin_version=3.1.1
+plugin_version=3.2
 plugin_archive=huskhomes
 
 jedis_version=4.2.3


### PR DESCRIPTION
Fixes for various issues. In particular, refactors the bulk deletion logic (`/delhome all` and `/delwarp all`)&mdash;as the existing logic was literally calling the delete methods on each and every saved position, locking the server at load as each one required a tick to fire the deletion event. To account for the need to expose API for deleting positions, this PR introduces two new events:
* DeleteAllHomesEvent
* DeleteAllWarpsEvent