### PR TITLE
Warp permission node fix

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/position/Warp.java
+++ b/common/src/main/java/net/william278/huskhomes/position/Warp.java
@@ -37,7 +37,7 @@ public class Warp extends SavedPosition {
     @NotNull
     @Subst("huskhomes.command.warp")
     public static String getPermissionNode(@NotNull String warp) {
-        return Permission.COMMAND_WARP + "." + warp.toLowerCase();
+        return Permission.COMMAND_WARP.node + "." + warp.toLowerCase();
     }
 
     /**


### PR DESCRIPTION
**Changes**
Fixed:
- restricted warps with granted permissions are not tab completed
- The player cannot teleport to locked warps because he does not have permission, although the permission is assigned

**Other**
The whole thing is so far tested in all the ways I could think of. The missing .node caused that COMMAND_WARP.<warpname> was used for the permission request. A player does not have this permission. Should fit now
