### PR TITLE
Add Paper Plugin support, Pl3xMap hook

### DIFF
--- a/.github/workflows/java_ci.yml
+++ b/.github/workflows/java_ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 16
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'

--- a/.github/workflows/java_ci.yml
+++ b/.github/workflows/java_ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 16
         uses: actions/setup-java@v3
         with:
-          java-version: '16'
+          java-version: '17'
           distribution: 'temurin'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
@@ -44,6 +44,7 @@ jobs:
           modrinth-dependencies: |
             bluemap | suggests | *
             dynmap | suggests | *
+            pl3xmap | suggests | *
           files-primary: target/HuskHomes-Plugin-*.jar
           name: HuskHomes v${{ env.version_name }}
           version: ${{ env.version_name }}

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 16
         uses: actions/setup-java@v3
         with:
-          java-version: '16'
+          java-version: '17'
           distribution: 'temurin'
       - name: Test Pull Request
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 16
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 .gradle
 build/
+run/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-/sponge/run/
 
 ### IntelliJ IDEA ###
 .idea/modules.xml

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ All of this is supported on standalone and cross-server setups; players can set 
 **⭐ Extensible API & open-source** &mdash; Still not enough? Extend the plugin with the HuskHomes API. Or, submit a pull request—we're open-source!
 
 ## Building
-To build HuskHomes, simply run the following in the root of the repository:
+HuskHomes requires Java 17 to build (required for Paper plugin 1.19.x support). To build, simply run the following in the root of the repository:
 
 ```bash
 ./gradlew clean build

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ import org.apache.tools.ant.filters.ReplaceTokens
 plugins {
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'org.ajoberstar.grgit' version '5.0.0'
-    id 'java'
     id 'maven-publish'
+    id 'java'
 }
 
 group 'net.william278'
@@ -31,9 +31,9 @@ allprojects {
         mavenCentral()
         maven { url 'https://libraries.minecraft.net/' }
         maven { url 'https://api.modrinth.com/maven' }
+        maven { url 'https://repo.papermc.io/repository/maven-public/' }
         maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
         maven { url 'https://repo.extendedclip.com/content/repositories/placeholderapi/' }
-        maven { url 'https://repo.papermc.io/repository/maven-public/' }
         maven { url 'https://repo.minebench.de/' }
         maven { url 'https://repo.alessiodp.com/releases/' }
         maven { url 'https://repo.mikeprimm.com/' }
@@ -62,40 +62,15 @@ subprojects {
     version rootProject.version
     archivesBaseName = "${rootProject.name}-${project.name.capitalize()}"
 
+    if ('paper'.contains(project.name)) {
+        compileJava.options.release.set 17
+    }
+
     if (['bukkit', 'paper', 'plugin'].contains(project.name)) {
         shadowJar {
             destinationDirectory.set(file("$rootDir/target"))
             archiveClassifier.set('')
         }
-
-        // API publishing
-        if ('bukkit'.contains(project.name)) {
-            java {
-                withSourcesJar()
-                withJavadocJar()
-            }
-            sourcesJar {
-                destinationDirectory.set(file("$rootDir/target"))
-            }
-            javadocJar {
-                destinationDirectory.set(file("$rootDir/target"))
-            }
-            shadowJar.dependsOn(sourcesJar, javadocJar)
-
-            publishing {
-                publications {
-                    mavenJava(MavenPublication) {
-                        groupId = 'net.william278'
-                        artifactId = 'huskhomes'
-                        version = "$rootProject.version"
-                        artifact shadowJar
-                        artifact javadocJar
-                        artifact sourcesJar
-                    }
-                }
-            }
-        }
-
         jar.dependsOn shadowJar
         clean.delete "$rootDir/target"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ subprojects {
     version rootProject.version
     archivesBaseName = "${rootProject.name}-${project.name.capitalize()}"
 
-    if (['bukkit', 'plugin'].contains(project.name)) {
+    if (['bukkit', 'paper', 'plugin'].contains(project.name)) {
         shadowJar {
             destinationDirectory.set(file("$rootDir/target"))
             archiveClassifier.set('')

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -1,7 +1,11 @@
+plugins {
+    id 'maven-publish'
+}
+
 dependencies {
     implementation project(path: ':common')
 
-    implementation 'org.bstats:bstats-bukkit:3.0.1'
+    implementation 'org.bstats:bstats-bukkit:3.0.2'
     implementation 'io.papermc:paperlib:1.0.8'
     implementation 'me.lucko:commodore:2.2'
     implementation 'net.kyori:adventure-platform-bukkit:4.3.0'
@@ -47,4 +51,16 @@ shadowJar {
     relocate 'org.bstats', 'net.william278.huskhomes.libraries.bstats'
     relocate 'io.papermc.lib', 'net.william278.huskhomes.libraries.paperlib'
     relocate 'me.lucko.commodore', 'net.william278.huskhomes.libraries.commodore'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            groupId = 'net.william278'
+            artifactId = 'huskhomes'
+            version = "$rootProject.version"
+
+            artifact jar
+        }
+    }
 }

--- a/bukkit/src/main/java/net/william278/huskhomes/command/BrigadierUtil.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/command/BrigadierUtil.java
@@ -3,7 +3,6 @@ package net.william278.huskhomes.command;
 import me.lucko.commodore.CommodoreProvider;
 import me.lucko.commodore.file.CommodoreFileReader;
 import net.william278.huskhomes.BukkitHuskHomes;
-import org.bukkit.command.PluginCommand;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -16,22 +15,22 @@ public class BrigadierUtil {
      * Uses commodore to register command completions
      *
      * @param plugin        instance of the registering Bukkit plugin
-     * @param pluginCommand the Bukkit PluginCommand to register completions for
+     * @param bukkitCommand the Bukkit PluginCommand to register completions for
      * @param command       the {@link Command} to register completions for
      */
-    protected static void registerCommodore(@NotNull BukkitHuskHomes plugin, @NotNull PluginCommand pluginCommand,
+    protected static void registerCommodore(@NotNull BukkitHuskHomes plugin, @NotNull org.bukkit.command.Command bukkitCommand,
                                             @NotNull Command command) {
-        final InputStream commandCommodore = plugin.getResource("commodore/" + pluginCommand.getName() + ".commodore");
+        final InputStream commandCommodore = plugin.getResource("commodore/" + bukkitCommand.getName() + ".commodore");
         if (commandCommodore == null) {
             return;
         }
         try {
-            CommodoreProvider.getCommodore(plugin).register(pluginCommand,
+            CommodoreProvider.getCommodore(plugin).register(bukkitCommand,
                     CommodoreFileReader.INSTANCE.parse(commandCommodore),
                     player -> player.hasPermission(command.getPermission()));
         } catch (IOException e) {
             plugin.log(Level.SEVERE, "Failed to read command commodore completions for "
-                                                         + pluginCommand.getName(), e);
+                                     + bukkitCommand.getName(), e);
         }
     }
 

--- a/bukkit/src/main/java/net/william278/huskhomes/command/BukkitCommand.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/command/BukkitCommand.java
@@ -54,14 +54,14 @@ public class BukkitCommand implements CommandExecutor, TabCompleter {
         }
 
         // Register permissions
-        addPermission(command.getPermission(), command.getUsage(), getPermissionDefault(command.isOperatorCommand()));
+        addPermission(plugin, command.getPermission(), command.getUsage(), getPermissionDefault(command.isOperatorCommand()));
         final List<Permission> childNodes = command.getAdditionalPermissions()
                 .entrySet().stream()
-                .map((entry) -> addPermission(entry.getKey(), "", getPermissionDefault(entry.getValue())))
+                .map((entry) -> addPermission(plugin, entry.getKey(), "", getPermissionDefault(entry.getValue())))
                 .filter(Objects::nonNull)
                 .toList();
         if (!childNodes.isEmpty()) {
-            addPermission(command.getPermission("*"), command.getUsage(), PermissionDefault.FALSE,
+            addPermission(plugin, command.getPermission("*"), command.getUsage(), PermissionDefault.FALSE,
                     childNodes.toArray(new Permission[0]));
         }
 
@@ -78,7 +78,8 @@ public class BukkitCommand implements CommandExecutor, TabCompleter {
     }
 
     @Nullable
-    private Permission addPermission(@NotNull String node, @NotNull String description, @NotNull PermissionDefault permissionDefault, @NotNull Permission... children) {
+    protected static Permission addPermission(@NotNull BukkitHuskHomes plugin, @NotNull String node, @NotNull String description,
+                                              @NotNull PermissionDefault permissionDefault, @NotNull Permission... children) {
         final Map<String, Boolean> childNodes = Arrays.stream(children)
                 .map(Permission::getName)
                 .collect(HashMap::new, (map, child) -> map.put(child, true), HashMap::putAll);
@@ -100,7 +101,7 @@ public class BukkitCommand implements CommandExecutor, TabCompleter {
     }
 
     @NotNull
-    private static PermissionDefault getPermissionDefault(boolean isOperatorCommand) {
+    protected static PermissionDefault getPermissionDefault(boolean isOperatorCommand) {
         return isOperatorCommand ? PermissionDefault.OP : PermissionDefault.TRUE;
     }
 

--- a/bukkit/src/test/java/net/william278/huskhomes/BukkitPluginTests.java
+++ b/bukkit/src/test/java/net/william278/huskhomes/BukkitPluginTests.java
@@ -6,7 +6,6 @@ import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import de.themoep.minedown.adventure.MineDown;
 import net.william278.huskhomes.command.BukkitCommand;
 import net.william278.huskhomes.command.Command;
-import net.william278.huskhomes.command.RtpCommand;
 import net.william278.huskhomes.position.*;
 import net.william278.huskhomes.user.BukkitUser;
 import net.william278.huskhomes.user.ConsoleUser;
@@ -25,9 +24,9 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
- * Uses MockBukkit to test the plugin on a mock Spigot server implementing the Bukkit 1.16 API.
+ * Uses MockBukkit to test the plugin on a mock Paper server implementing the Bukkit 1.16 API.
  */
-@DisplayName("Bukkit Plugin Tests")
+@DisplayName("Bukkit Plugin Tests (1.16.5)")
 public class BukkitPluginTests {
 
     private static ServerMock server;
@@ -154,7 +153,6 @@ public class BukkitPluginTests {
 
             final BukkitUser playerUser = BukkitUser.adapt(player);
             return commands.stream()
-                    .filter(command -> !(command instanceof RtpCommand))
                     .flatMap(command -> Stream.of(Arguments.of(command, playerUser, command.getName())));
         }
 
@@ -162,7 +160,6 @@ public class BukkitPluginTests {
             final List<Command> commands = plugin.getCommands();
             final ConsoleUser console = plugin.getConsole();
             return commands.stream()
-                    .filter(command -> !(command instanceof RtpCommand))
                     .flatMap(command -> Stream.of(Arguments.of(command, console, command.getName())));
         }
 

--- a/common/src/main/java/net/william278/huskhomes/HuskHomes.java
+++ b/common/src/main/java/net/william278/huskhomes/HuskHomes.java
@@ -414,7 +414,7 @@ public interface HuskHomes extends TaskRunner, EventDispatcher {
             throw new IllegalArgumentException("Cannot create a key with no data");
         }
         @Subst("foo") final String joined = String.join("/", data);
-        return Key.key("husktowns", joined);
+        return Key.key("huskhomes", joined);
     }
 
     @NotNull

--- a/common/src/main/java/net/william278/huskhomes/HuskHomes.java
+++ b/common/src/main/java/net/william278/huskhomes/HuskHomes.java
@@ -3,6 +3,7 @@ package net.william278.huskhomes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import net.kyori.adventure.key.Key;
+import net.william278.annotaml.Annotaml;
 import net.william278.desertwell.UpdateChecker;
 import net.william278.desertwell.Version;
 import net.william278.huskhomes.command.Command;
@@ -12,9 +13,7 @@ import net.william278.huskhomes.config.Settings;
 import net.william278.huskhomes.config.Spawn;
 import net.william278.huskhomes.database.Database;
 import net.william278.huskhomes.event.EventDispatcher;
-import net.william278.huskhomes.hook.EconomyHook;
-import net.william278.huskhomes.hook.Hook;
-import net.william278.huskhomes.hook.MapHook;
+import net.william278.huskhomes.hook.*;
 import net.william278.huskhomes.manager.Manager;
 import net.william278.huskhomes.network.Broker;
 import net.william278.huskhomes.position.Location;
@@ -26,13 +25,17 @@ import net.william278.huskhomes.user.OnlineUser;
 import net.william278.huskhomes.user.SavedUser;
 import net.william278.huskhomes.user.User;
 import net.william278.huskhomes.util.TaskRunner;
+import net.william278.huskhomes.util.ThrowingConsumer;
+import net.william278.huskhomes.util.UnsafeBlocks;
 import net.william278.huskhomes.util.Validator;
 import org.intellij.lang.annotations.Subst;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -75,6 +78,22 @@ public interface HuskHomes extends TaskRunner, EventDispatcher {
     }
 
     /**
+     * Initialize a faucet of the plugin
+     *
+     * @param name   the name of the faucet
+     * @param runner a runnable for initializing the faucet
+     */
+    default void initialize(@NotNull String name, @NotNull ThrowingConsumer<HuskHomes> runner) {
+        log(Level.INFO, "Initializing " + name + "...");
+        try {
+            runner.accept(this);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to initialize " + name, e);
+        }
+        log(Level.INFO, "Successfully initialized " + name);
+    }
+
+    /**
      * Finds a local {@link OnlineUser} by their name. Auto-completes partially typed names for the closest match
      *
      * @param playerName the name of the player to find
@@ -98,6 +117,8 @@ public interface HuskHomes extends TaskRunner, EventDispatcher {
     @NotNull
     Settings getSettings();
 
+    void setSettings(@NotNull Settings settings);
+
     /**
      * The plugin messages loaded from file
      *
@@ -105,6 +126,41 @@ public interface HuskHomes extends TaskRunner, EventDispatcher {
      */
     @NotNull
     Locales getLocales();
+
+    void setLocales(@NotNull Locales locales);
+
+    /**
+     * The local {@link Spawn} location of this server, as cached to disk
+     *
+     * @return the {@link Spawn} location data
+     * @see #getSpawn() for the canonical spawn point to use
+     */
+    Optional<Spawn> getServerSpawn();
+
+    void setServerSpawn(@NotNull Spawn spawn);
+
+    /**
+     * The canonical spawn {@link Position} of this server, if it has been set
+     *
+     * @return the {@link Position} of the spawn, or an empty {@link Optional} if it has not been set
+     */
+    default Optional<Position> getSpawn() {
+        return getSettings().doCrossServer() && getSettings().isGlobalSpawn()
+                ? getDatabase().getWarp(getSettings().getGlobalSpawnName()).map(warp -> (Position) warp)
+                : getServerSpawn().map(spawn -> spawn.getPosition(getServerName()));
+    }
+
+    /**
+     * Returns the {@link Server} the plugin is on
+     *
+     * @return The {@link Server} object
+     */
+    @NotNull
+    String getServerName();
+
+    void setServer(@NotNull Server server);
+
+    void setUnsafeBlocks(@NotNull UnsafeBlocks unsafeBlocks);
 
     /**
      * The {@link Database} that stores persistent plugin data
@@ -153,24 +209,6 @@ public interface HuskHomes extends TaskRunner, EventDispatcher {
      */
     void setRandomTeleportEngine(@NotNull RandomTeleportEngine randomTeleportEngine);
 
-    /**
-     * The local {@link Spawn} location of this server, as cached to disk
-     *
-     * @return the {@link Spawn} location data
-     * @see #getSpawn() for the canonical spawn point to use
-     */
-    Optional<Spawn> getLocalCachedSpawn();
-
-    /**
-     * The canonical spawn {@link Position} of this server, if it has been set
-     *
-     * @return the {@link Position} of the spawn, or an empty {@link Optional} if it has not been set
-     */
-    default Optional<Position> getSpawn() {
-        return getSettings().doCrossServer() && getSettings().isGlobalSpawn()
-                ? getDatabase().getWarp(getSettings().getGlobalSpawnName()).map(warp -> (Position) warp)
-                : getLocalCachedSpawn().map(spawn -> spawn.getPosition(getServerName()));
-    }
 
     /**
      * Update the {@link Spawn} position to a location on the server
@@ -186,6 +224,8 @@ public interface HuskHomes extends TaskRunner, EventDispatcher {
      */
     @NotNull
     List<Hook> getHooks();
+
+    void setHooks(@NotNull List<Hook> hooks);
 
     default <T extends Hook> Optional<T> getHook(@NotNull Class<T> hookClass) {
         return getHooks().stream()
@@ -252,15 +292,7 @@ public interface HuskHomes extends TaskRunner, EventDispatcher {
      * @return a {@link CompletableFuture} that will complete with an optional of the safe ground position, if it is
      * possible to find one
      */
-    CompletableFuture<Optional<Location>> resolveSafeGroundLocation(@NotNull Location location);
-
-    /**
-     * Returns the {@link Server} the plugin is on
-     *
-     * @return The {@link Server} object
-     */
-    @NotNull
-    String getServerName();
+    CompletableFuture<Optional<Location>> findSafeGroundLocation(@NotNull Location location);
 
     /**
      * Returns a resource read from the plugin resources folder
@@ -311,6 +343,26 @@ public interface HuskHomes extends TaskRunner, EventDispatcher {
     }
 
     @NotNull
+    List<Command> registerCommands();
+
+    default void registerHooks() {
+        final ArrayList<Hook> hooks = new ArrayList<>();
+        if (getSettings().doMapHook()) {
+            if (isDependencyLoaded("Dynmap")) {
+                getHooks().add(new DynmapHook(this));
+            } else if (isDependencyLoaded("BlueMap")) {
+                getHooks().add(new BlueMapHook(this));
+            }
+        }
+        if (isDependencyLoaded("Plan")) {
+            getHooks().add(new PlanHook(this));
+        }
+        setHooks(hooks);
+    }
+
+    boolean isDependencyLoaded(@NotNull String name);
+
+    @NotNull
     Map<String, List<String>> getGlobalPlayerList();
 
     @NotNull
@@ -355,7 +407,38 @@ public interface HuskHomes extends TaskRunner, EventDispatcher {
      * @return {@code true} if the reload was successful, {@code false} otherwise
      */
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    boolean loadConfigs();
+    default boolean loadConfigs() {
+        try {
+            // Load settings
+            setSettings(Annotaml.create(new File(getDataFolder(), "config.yml"), Settings.class).get());
+
+            // Load locales from language preset default
+            final Locales languagePresets = Annotaml.create(Locales.class, Objects.requireNonNull(getResource("locales/" + getSettings().getLanguage() + ".yml"))).get();
+            setLocales(Annotaml.create(new File(getDataFolder(), "messages_" + getSettings().getLanguage() + ".yml"), languagePresets).get());
+
+            // Load server from file
+            if (getSettings().doCrossServer()) {
+                setServer(Annotaml.create(new File(getDataFolder(), "server.yml"), Server.class).get());
+            } else {
+                setServer(new Server(Server.getDefaultServerName()));
+            }
+
+            // Load spawn location from file
+            final File spawnFile = new File(getDataFolder(), "spawn.yml");
+            if (spawnFile.exists()) {
+                setServerSpawn(Annotaml.create(spawnFile, Spawn.class).get());
+            }
+
+            // Load unsafe blocks from resources
+            final InputStream blocksResource = getResource("safety/unsafe_blocks.yml");
+            setUnsafeBlocks(Annotaml.create(new UnsafeBlocks(), Objects.requireNonNull(blocksResource)).get());
+
+            return true;
+        } catch (IOException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
+            log(Level.SEVERE, "Failed to reload HuskHomes config or messages file", e);
+        }
+        return false;
+    }
 
     @NotNull
     default UpdateChecker getUpdateChecker() {

--- a/common/src/main/java/net/william278/huskhomes/random/NormalDistributionEngine.java
+++ b/common/src/main/java/net/william278/huskhomes/random/NormalDistributionEngine.java
@@ -61,7 +61,7 @@ public final class NormalDistributionEngine extends RandomTeleportEngine {
      * @return A generated location
      */
     private CompletableFuture<Optional<Location>> generateSafeLocation(@NotNull World world) {
-        return plugin.resolveSafeGroundLocation(generateLocation(
+        return plugin.findSafeGroundLocation(generateLocation(
                 getCenterPoint(world), mean, standardDeviation, spawnRadius, radius));
     }
 

--- a/common/src/main/java/net/william278/huskhomes/random/RandomTeleportEngine.java
+++ b/common/src/main/java/net/william278/huskhomes/random/RandomTeleportEngine.java
@@ -40,7 +40,7 @@ public abstract class RandomTeleportEngine {
      */
     @NotNull
     protected Position getCenterPoint(@NotNull World world) {
-        return plugin.getLocalCachedSpawn()
+        return plugin.getServerSpawn()
                 .map(s -> s.getPosition(plugin.getServerName()))
                 .orElse(Position.at(0d, 128d, 0d, 0f, 0f,
                         world, plugin.getServerName()));

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.daemon=true
 javaVersion=16
 
-plugin_version=4.0.6
+plugin_version=4.1
 plugin_archive=huskhomes
 
 jedis_version=4.3.1

--- a/paper/build.gradle
+++ b/paper/build.gradle
@@ -1,0 +1,43 @@
+dependencies {
+    implementation project(path: ':bukkit')
+
+    compileOnly 'io.papermc.paper:paper-api:1.19.3-R0.1-SNAPSHOT'
+
+    compileOnly 'org.bstats:bstats-bukkit:3.0.1'
+    compileOnly 'io.papermc:paperlib:1.0.8'
+    compileOnly 'me.lucko:commodore:2.2'
+    compileOnly 'net.kyori:adventure-platform-bukkit:4.3.0'
+    compileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'de.themoep:minedown-adventure:1.7.2-SNAPSHOT'
+    compileOnly 'net.william278:Annotaml:2.0.1'
+    compileOnly 'net.william278:DesertWell:1.1.1'
+    compileOnly 'com.github.MilkBowl:VaultAPI:1.7.1'
+    compileOnly 'com.github.Emibergo02:RedisEconomy:9f4f9c86f4'
+    compileOnly 'me.clip:placeholderapi:2.11.3'
+}
+
+shadowJar {
+    dependencies {
+        exclude(dependency('com.mojang:brigadier'))
+        exclude(dependency('io.papermc:paperlib'))
+        exclude(dependency('net.kyori:adventure-platform-bukkit'))
+    }
+
+    relocate 'org.apache.commons.io', 'net.william278.huskhomes.libraries.commons.io'
+    relocate 'org.apache.commons.text', 'net.william278.huskhomes.libraries.commons.text'
+    relocate 'org.apache.commons.lang3', 'net.william278.huskhomes.libraries.commons.lang3'
+    relocate 'de.themoep', 'net.william278.huskhomes.libraries'
+    relocate 'org.jetbrains', 'net.william278.huskhomes.libraries'
+    relocate 'org.intellij', 'net.william278.huskhomes.libraries'
+    relocate 'com.zaxxer', 'net.william278.huskhomes.libraries'
+    relocate 'net.william278.annotaml', 'net.william278.huskhomes.libraries.annotaml'
+    relocate 'net.william278.paginedown', 'net.william278.huskhomes.libraries.paginedown'
+    relocate 'net.william278.desertwell', 'net.william278.huskhomes.libraries.desertwell'
+    relocate 'dev.dejvokep.boostedyaml', 'net.william278.huskhomes.libraries.boostedyaml'
+    relocate 'org.yaml.snakeyaml', 'net.william278.huskhomes.libraries.snakeyaml'
+    relocate 'com.google.gson', 'net.william278.huskhomes.libraries.gson'
+    relocate 'net.kyori', 'net.william278.huskhomes.libraries'
+    relocate 'org.bstats', 'net.william278.huskhomes.libraries.bstats'
+    relocate 'io.papermc.lib', 'net.william278.huskhomes.libraries.paperlib'
+    relocate 'me.lucko.commodore', 'net.william278.huskhomes.libraries.commodore'
+}

--- a/paper/build.gradle
+++ b/paper/build.gradle
@@ -1,16 +1,20 @@
+plugins {
+    id 'xyz.jpenilla.run-paper' version '2.0.0'
+}
+
 dependencies {
+    compileOnly project(path: ':common')
     implementation project(path: ':bukkit')
 
     compileOnly 'io.papermc.paper:paper-api:1.19.3-R0.1-SNAPSHOT'
+    compileOnly 'maven.modrinth:pl3xmap:1.19.3-321'
 
-    compileOnly 'org.bstats:bstats-bukkit:3.0.1'
-    compileOnly 'io.papermc:paperlib:1.0.8'
-    compileOnly 'me.lucko:commodore:2.2'
-    compileOnly 'net.kyori:adventure-platform-bukkit:4.3.0'
+    compileOnly 'org.bstats:bstats-bukkit:3.0.2'
     compileOnly 'org.jetbrains:annotations:24.0.1'
     compileOnly 'de.themoep:minedown-adventure:1.7.2-SNAPSHOT'
     compileOnly 'net.william278:Annotaml:2.0.1'
     compileOnly 'net.william278:DesertWell:1.1.1'
+    compileOnly 'me.lucko:commodore:2.2'
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7.1'
     compileOnly 'com.github.Emibergo02:RedisEconomy:9f4f9c86f4'
     compileOnly 'me.clip:placeholderapi:2.11.3'
@@ -19,8 +23,6 @@ dependencies {
 shadowJar {
     dependencies {
         exclude(dependency('com.mojang:brigadier'))
-        exclude(dependency('io.papermc:paperlib'))
-        exclude(dependency('net.kyori:adventure-platform-bukkit'))
     }
 
     relocate 'org.apache.commons.io', 'net.william278.huskhomes.libraries.commons.io'
@@ -40,4 +42,10 @@ shadowJar {
     relocate 'org.bstats', 'net.william278.huskhomes.libraries.bstats'
     relocate 'io.papermc.lib', 'net.william278.huskhomes.libraries.paperlib'
     relocate 'me.lucko.commodore', 'net.william278.huskhomes.libraries.commodore'
+}
+
+tasks {
+    runServer {
+        minecraftVersion('1.19.4')
+    }
 }

--- a/paper/src/main/java/net/william278/huskhomes/PaperHuskHomes.java
+++ b/paper/src/main/java/net/william278/huskhomes/PaperHuskHomes.java
@@ -1,4 +1,42 @@
 package net.william278.huskhomes;
 
-public class PaperHuskHomes {
+import net.william278.huskhomes.command.BukkitCommand;
+import net.william278.huskhomes.command.Command;
+import net.william278.huskhomes.command.PaperCommand;
+import net.william278.huskhomes.hook.Pl3xMapHook;
+import org.bukkit.Bukkit;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class PaperHuskHomes extends BukkitHuskHomes {
+
+    @Override
+    protected void prepareHooks() {
+        super.prepareHooks();
+
+        if (getMapHook().isEmpty() && Bukkit.getServer().getPluginManager().getPlugin("Pl3xMap") != null) {
+            getHooks().add(new Pl3xMapHook(this));
+        }
+    }
+
+    @NotNull
+    @Override
+    protected List<Command> registerCommands() {
+        return Arrays.stream(BukkitCommand.Type.values())
+                .map(type -> {
+                    final Command command = type.getCommand();
+                    if (!getSettings().isCommandDisabled(command)) {
+                        new PaperCommand(command, this).register();
+                        return command;
+                    }
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/paper/src/main/java/net/william278/huskhomes/PaperHuskHomes.java
+++ b/paper/src/main/java/net/william278/huskhomes/PaperHuskHomes.java
@@ -4,7 +4,6 @@ import net.william278.huskhomes.command.BukkitCommand;
 import net.william278.huskhomes.command.Command;
 import net.william278.huskhomes.command.PaperCommand;
 import net.william278.huskhomes.hook.Pl3xMapHook;
-import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -15,17 +14,17 @@ import java.util.stream.Collectors;
 public class PaperHuskHomes extends BukkitHuskHomes {
 
     @Override
-    protected void prepareHooks() {
-        super.prepareHooks();
+    public void registerHooks() {
+        super.registerHooks();
 
-        if (getMapHook().isEmpty() && Bukkit.getServer().getPluginManager().getPlugin("Pl3xMap") != null) {
+        if (getMapHook().isEmpty() && isDependencyLoaded("Pl3xMap")) {
             getHooks().add(new Pl3xMapHook(this));
         }
     }
 
     @NotNull
     @Override
-    protected List<Command> registerCommands() {
+    public List<Command> registerCommands() {
         return Arrays.stream(BukkitCommand.Type.values())
                 .map(type -> {
                     final Command command = type.getCommand();

--- a/paper/src/main/java/net/william278/huskhomes/PaperHuskHomes.java
+++ b/paper/src/main/java/net/william278/huskhomes/PaperHuskHomes.java
@@ -1,0 +1,4 @@
+package net.william278.huskhomes;
+
+public class PaperHuskHomes {
+}

--- a/paper/src/main/java/net/william278/huskhomes/PaperHuskHomesLoader.java
+++ b/paper/src/main/java/net/william278/huskhomes/PaperHuskHomesLoader.java
@@ -1,0 +1,57 @@
+package net.william278.huskhomes;
+
+import io.papermc.paper.plugin.loader.PluginClasspathBuilder;
+import io.papermc.paper.plugin.loader.PluginLoader;
+import io.papermc.paper.plugin.loader.library.impl.MavenLibraryResolver;
+import net.william278.annotaml.Annotaml;
+import net.william278.annotaml.YamlFile;
+import net.william278.annotaml.YamlKey;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Objects;
+
+@SuppressWarnings({"UnstableApiUsage", "unused"})
+public class PaperHuskHomesLoader implements PluginLoader {
+
+    @Override
+    public void classloader(@NotNull PluginClasspathBuilder classpathBuilder) {
+        MavenLibraryResolver resolver = new MavenLibraryResolver();
+
+        resolveLibraries(classpathBuilder).stream()
+                .map(DefaultArtifact::new)
+                .forEach(artifact -> resolver.addDependency(new Dependency(artifact, null)));
+        resolver.addRepository(new RemoteRepository.Builder(
+                "maven", "default", "https://repo.maven.apache.org/maven2/"
+        ).build());
+
+        classpathBuilder.addLibrary(resolver);
+    }
+
+    @NotNull
+    private static List<String> resolveLibraries(@NotNull PluginClasspathBuilder classpathBuilder) {
+        try (InputStream input = PaperHuskHomesLoader.class.getClassLoader().getResourceAsStream("paper-libraries.yml")) {
+            return Annotaml.create(PaperLibraries.class, Objects.requireNonNull(input)).get().libraries;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return List.of();
+    }
+
+    @YamlFile(header = "Dependencies for HuskHomes on Paper")
+    public static class PaperLibraries {
+
+        @YamlKey("libraries")
+        private List<String> libraries;
+
+        @SuppressWarnings("unused")
+        private PaperLibraries() {
+        }
+
+    }
+
+}

--- a/paper/src/main/java/net/william278/huskhomes/command/PaperCommand.java
+++ b/paper/src/main/java/net/william278/huskhomes/command/PaperCommand.java
@@ -1,0 +1,65 @@
+package net.william278.huskhomes.command;
+
+import me.lucko.commodore.CommodoreProvider;
+import net.william278.huskhomes.PaperHuskHomes;
+import net.william278.huskhomes.user.BukkitUser;
+import net.william278.huskhomes.user.CommandUser;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionDefault;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Objects;
+
+public class PaperCommand extends org.bukkit.command.Command {
+
+    private final PaperHuskHomes plugin;
+    private final Command command;
+
+    public PaperCommand(@NotNull Command command, @NotNull PaperHuskHomes plugin) {
+        super(command.getName(), command.getDescription(), command.getUsage(), command.getAliases());
+        this.command = command;
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean execute(@NotNull CommandSender sender, @NotNull String commandLabel, @NotNull String[] args) {
+        this.command.onExecuted(sender instanceof Player player ? BukkitUser.adapt(player) : plugin.getConsole(), args);
+        return true;
+    }
+
+    @NotNull
+    @Override
+    public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String alias, @NotNull String[] args) throws IllegalArgumentException {
+        if (!(this.command instanceof TabProvider provider)) {
+            return List.of();
+        }
+        final CommandUser user = sender instanceof Player player ? BukkitUser.adapt(player) : plugin.getConsole();
+        return provider.getSuggestions(user, args);
+    }
+
+    public void register() {
+        // Register with bukkit
+        plugin.getServer().getCommandMap().register("huskhomes", this);
+
+        // Register permissions
+        BukkitCommand.addPermission(plugin, command.getPermission(), command.getUsage(), BukkitCommand.getPermissionDefault(command.isOperatorCommand()));
+        final List<Permission> childNodes = command.getAdditionalPermissions()
+                .entrySet().stream()
+                .map((entry) -> BukkitCommand.addPermission(plugin, entry.getKey(), "", BukkitCommand.getPermissionDefault(entry.getValue())))
+                .filter(Objects::nonNull)
+                .toList();
+        if (!childNodes.isEmpty()) {
+            BukkitCommand.addPermission(plugin, command.getPermission("*"), command.getUsage(), PermissionDefault.FALSE,
+                    childNodes.toArray(new Permission[0]));
+        }
+
+        // Register commodore TAB completion
+        if (CommodoreProvider.isSupported() && plugin.getSettings().doBrigadierTabCompletion()) {
+            BrigadierUtil.registerCommodore(plugin, this, command);
+        }
+    }
+
+}

--- a/paper/src/main/java/net/william278/huskhomes/hook/Pl3xMapHook.java
+++ b/paper/src/main/java/net/william278/huskhomes/hook/Pl3xMapHook.java
@@ -1,0 +1,191 @@
+package net.william278.huskhomes.hook;
+
+import net.pl3x.map.Key;
+import net.pl3x.map.Pl3xMap;
+import net.pl3x.map.event.EventHandler;
+import net.pl3x.map.event.EventListener;
+import net.pl3x.map.event.server.ServerLoadedEvent;
+import net.pl3x.map.event.world.WorldLoadedEvent;
+import net.pl3x.map.event.world.WorldUnloadedEvent;
+import net.pl3x.map.image.IconImage;
+import net.pl3x.map.markers.Point;
+import net.pl3x.map.markers.layer.SimpleLayer;
+import net.pl3x.map.markers.marker.Icon;
+import net.pl3x.map.markers.marker.Marker;
+import net.pl3x.map.world.World;
+import net.william278.huskhomes.HuskHomes;
+import net.william278.huskhomes.position.Home;
+import net.william278.huskhomes.position.Warp;
+import net.william278.huskhomes.user.User;
+import org.jetbrains.annotations.NotNull;
+
+import javax.imageio.ImageIO;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+public class Pl3xMapHook extends MapHook implements EventListener {
+
+    private final ConcurrentLinkedQueue<Home> publicHomes = new ConcurrentLinkedQueue<>();
+    private final ConcurrentLinkedQueue<Warp> warps = new ConcurrentLinkedQueue<>();
+    private final Key warpsLayerKey;
+    private final Key publicHomesLayerKey;
+
+    public Pl3xMapHook(@NotNull HuskHomes plugin) {
+        super(plugin, "Pl3xMap");
+        this.warpsLayerKey = Key.of("warp_markers");
+        this.publicHomesLayerKey = Key.of("public_home_markers");
+    }
+
+    @Override
+    public void initialize() {
+        Pl3xMap.api().getEventRegistry().register(this);
+
+        if (plugin.getSettings().doWarpsOnMap()) {
+            this.registerIcon(warpsLayerKey, "markers/16x/warp.png");
+        }
+        if (plugin.getSettings().doPublicHomesOnMap()) {
+            this.registerIcon(publicHomesLayerKey, "markers/16x/public-home.png");
+        }
+
+        plugin.runAsync(() -> {
+            plugin.getDatabase().getLocalPublicHomes(plugin).forEach(this::updateHome);
+            plugin.getDatabase().getLocalWarps(plugin).forEach(this::updateWarp);
+        });
+    }
+
+    @Override
+    public void updateHome(@NotNull Home home) {
+        publicHomes.remove(home);
+        if (isValidPosition(home)) {
+            publicHomes.add(home);
+        }
+    }
+
+    @Override
+    public void removeHome(@NotNull Home home) {
+        publicHomes.remove(home);
+    }
+
+    @Override
+    public void clearHomes(@NotNull User user) {
+        publicHomes.removeIf(home -> home.getOwner().equals(user));
+    }
+
+    @Override
+    public void updateWarp(@NotNull Warp warp) {
+        warps.remove(warp);
+        if (isValidPosition(warp)) {
+            warps.add(warp);
+        }
+    }
+
+    @Override
+    public void removeWarp(@NotNull Warp warp) {
+        warps.remove(warp);
+    }
+
+    @Override
+    public void clearWarps() {
+        warps.clear();
+    }
+
+    private void registerIcon(@NotNull Key key, @NotNull String iconFileName) {
+        try (InputStream iconStream = plugin.getResource(iconFileName)) {
+            if (iconStream == null) {
+                plugin.log(Level.WARNING, "Failed to load Pl3xMap icon for warps: icon file not found");
+                return;
+            }
+            Pl3xMap.api().getIconRegistry().register(new IconImage(key, ImageIO.read(iconStream), "png"));
+        } catch (IOException e) {
+            plugin.log(Level.WARNING, "Failed to load Pl3xMap icon for warps: " + e.getMessage());
+        }
+    }
+
+    private void registerLayers(@NotNull World world) {
+        if (plugin.getSettings().doWarpsOnMap()) {
+            WarpsLayer layer = new WarpsLayer(this, world);
+            world.getLayerRegistry().register(layer);
+        }
+        if (plugin.getSettings().doPublicHomesOnMap()) {
+            PublicHomesLayer layer = new PublicHomesLayer(this, world);
+            world.getLayerRegistry().register(layer);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @EventHandler
+    public void onServerLoaded(ServerLoadedEvent event) {
+        Pl3xMap.api().getWorldRegistry().entries().values().forEach(this::registerLayers);
+    }
+
+    @SuppressWarnings("unused")
+    @EventHandler
+    public void onWorldLoaded(WorldLoadedEvent event) {
+        registerLayers(event.getWorld());
+    }
+
+    @SuppressWarnings("unused")
+    @EventHandler
+    public void onWorldUnloaded(WorldUnloadedEvent event) {
+        event.getWorld().getLayerRegistry().unregister(warpsLayerKey);
+        event.getWorld().getLayerRegistry().unregister(publicHomesLayerKey);
+    }
+
+    public static class WarpsLayer extends SimpleLayer {
+
+        private final Pl3xMapHook hook;
+        private final World mapWorld;
+
+        public WarpsLayer(@NotNull Pl3xMapHook hook, @NotNull World mapWorld) {
+            super(hook.warpsLayerKey, hook::getWarpsMarkerSetName);
+            this.hook = hook;
+            this.mapWorld = mapWorld;
+        }
+
+        @Override
+        @NotNull
+        public Collection<Marker<?>> getMarkers() {
+            return hook.warps.stream()
+                    .filter(warp -> warp.getWorld().getName().equals(mapWorld.getName()))
+                    .map(warp -> Icon.of(
+                            Key.of("warp_" + warp.getUuid()),
+                            Point.of(warp.getX(), warp.getZ()),
+                            hook.warpsLayerKey
+                    ))
+                    .collect(Collectors.toCollection(LinkedList::new));
+        }
+
+    }
+
+    public static class PublicHomesLayer extends SimpleLayer {
+
+        private final Pl3xMapHook hook;
+        private final World mapWorld;
+
+        public PublicHomesLayer(@NotNull Pl3xMapHook hook, @NotNull World mapWorld) {
+            super(hook.publicHomesLayerKey, hook::getPublicHomesMarkerSetName);
+            this.hook = hook;
+            this.mapWorld = mapWorld;
+        }
+
+        @Override
+        @NotNull
+        public Collection<Marker<?>> getMarkers() {
+            return hook.publicHomes.stream()
+                    .filter(home -> home.getWorld().getName().equals(mapWorld.getName()))
+                    .map(home -> Icon.of(
+                            Key.of("public_home_" + home.getUuid()),
+                            Point.of(home.getX(), home.getZ()),
+                            hook.publicHomesLayerKey
+                    ))
+                    .collect(Collectors.toCollection(LinkedList::new));
+        }
+
+    }
+
+}

--- a/paper/src/main/java/net/william278/huskhomes/hook/Pl3xMapHook.java
+++ b/paper/src/main/java/net/william278/huskhomes/hook/Pl3xMapHook.java
@@ -97,12 +97,12 @@ public class Pl3xMapHook extends MapHook implements EventListener {
     private void registerIcon(@NotNull Key key, @NotNull String iconFileName) {
         try (InputStream iconStream = plugin.getResource(iconFileName)) {
             if (iconStream == null) {
-                plugin.log(Level.WARNING, "Failed to load Pl3xMap icon for warps: icon file not found");
+                plugin.log(Level.WARNING, "Failed to load Pl3xMap icon ("+ key + "): icon file not found");
                 return;
             }
             Pl3xMap.api().getIconRegistry().register(new IconImage(key, ImageIO.read(iconStream), "png"));
         } catch (IOException e) {
-            plugin.log(Level.WARNING, "Failed to load Pl3xMap icon for warps: " + e.getMessage());
+            plugin.log(Level.WARNING, "Failed to load Pl3xMap icon ("+ key + "): " + e.getMessage(), e);
         }
     }
 

--- a/paper/src/main/resources/paper-libraries.yml
+++ b/paper/src/main/resources/paper-libraries.yml
@@ -1,0 +1,5 @@
+# Dependencies for HuskHomes on Paper
+libraries:
+  - 'redis.clients:jedis:${jedis_version}'
+  - 'com.mysql:mysql-connector-j:${mysql_driver_version}'
+  - 'org.xerial:sqlite-jdbc:${sqlite_driver_version}'

--- a/paper/src/main/resources/paper-plugin.yml
+++ b/paper/src/main/resources/paper-plugin.yml
@@ -3,6 +3,90 @@ description: 'A powerful, intuitive and flexible teleportation suite'
 author: 'William278'
 website: 'https://william278.net/'
 main: 'net.william278.huskhomes.PaperHuskHomes'
-loader: 'net.william278.huskhomes.PaperPluginLoader'
+loader: 'net.william278.huskhomes.PaperHuskHomesLoader'
 version: '${version}'
 api-version: 1.19
+dependencies:
+  - name: Vault
+    required: false
+  - name: RedisEconomy
+    required: false
+  - name: dynmap
+    required: false
+  - name: BlueMap
+    required: false
+  - name: Plan
+    required: false
+  - name: Pl3xMap
+    required: false
+load-after:
+  - name: Vault
+  - name: RedisEconomy
+  - name: dynmap
+  - name: BlueMap
+  - name: Plan
+  - name: Pl3xMap
+
+commands:
+  home:
+    usage: /home <name>
+  sethome:
+    usage: /sethome <name>
+  homelist:
+    usage: /homelist [player] [page]
+    aliases: [homes]
+  delhome:
+    usage: /delhome <name>
+  edithome:
+    usage: /edithome <name> [rename|description|relocate|privacy] [args]
+  phome:
+    usage: /phome [<owner_name>.<home_name>]
+    aliases:  [publichome]
+  phomelist:
+    usage: /phomelist [page]
+    aliases:  [publichomelist, phomes]
+  warp:
+    usage: /warp <name>
+  setwarp:
+    usage: /setwarp <name>
+  warplist:
+    usage: /warplist [page]
+    aliases: [warps]
+  delwarp:
+    usage: /delwarp <name>
+  editwarp:
+    usage: /editwarp <name> [rename|description|relocate] [args]
+  tp:
+    usage: /tp <target> [destination]
+    aliases: [tpo]
+  tphere:
+    usage: /tphere <player>
+    aliases: [tpohere]
+  tpa:
+    usage: /tpa <player>
+  tpahere:
+    usage: /tpahere <player>
+  tpaccept:
+    usage: /tpaccept [player]
+    aliases: [tpyes]
+  tpdecline:
+    usage: /tpdecline [player]
+    aliases: [tpdeny, tpno]
+  rtp:
+    usage: /rtp [player]
+  tpignore:
+    usage: /tpignore
+  tpoffline:
+    usage: /tpoffline <player>
+  tpall:
+    usage: /tpall
+  tpaall:
+    usage: /tpaall
+  spawn:
+    usage: /spawn
+  setspawn:
+    usage: /setspawn
+  back:
+    usage: /back
+  huskhomes:
+    usage: /huskhomes [about|help|reload|update]

--- a/paper/src/main/resources/paper-plugin.yml
+++ b/paper/src/main/resources/paper-plugin.yml
@@ -1,0 +1,8 @@
+name: 'HuskHomes'
+description: 'A powerful, intuitive and flexible teleportation suite'
+author: 'William278'
+website: 'https://william278.net/'
+main: 'net.william278.huskhomes.PaperHuskHomes'
+loader: 'net.william278.huskhomes.PaperPluginLoader'
+version: '${version}'
+api-version: 1.19

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
     implementation project(path: ':bukkit', configuration: 'shadow')
+    runtimeOnly project(path: ':paper')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,4 +8,5 @@ rootProject.name = 'HuskHomes'
 
 include 'common'
 include 'bukkit'
+include 'paper'
 include 'plugin'


### PR DESCRIPTION
This pull request adds experimental native Paper plugin support, allowing HuskHomes to leverage the various benefits that brings with it (native adventure support, paper plugin compatibility, runtime command registering, additional events etc). Installing HuskHomes on a Paper 1.19.4 will let you use this mode, which currently has two differences:

* The Paper plugin implementation supports Pl3xMap (v2) as a map hook, letting you display public homes & warps on your Pl3xMap (see below).
* Disabled commands won't register at all on the Paper implementation (no disabled command message will show; instead "unknown command" will always appear

<details>
<summary>Pl3xMap feature preview</summary>

![image](https://user-images.githubusercontent.com/31187453/228609462-b7cc95f0-d5f8-4b17-b8e7-256006516835.png)

</details>

No changes should be notable on non-paper platforms. This includes Paper <=1.19.3, which this doesn't support. Note this is subject to change as the Paper Plugin specification is still in development, and it's my intent to improve a few other things to make paper users' experiences even better down the road.