### PR TITLE
Add ability to resolve unsafe positions by UUID where the identifier would otherwise be unsafe

### DIFF
--- a/bukkit/src/test/java/net/william278/huskhomes/BukkitPluginTests.java
+++ b/bukkit/src/test/java/net/william278/huskhomes/BukkitPluginTests.java
@@ -379,7 +379,6 @@ public class BukkitPluginTests {
                     .anyMatch(home -> home.equals(name)));
         }
 
-        // rename
         @DisplayName("Test Home Renaming")
         @ParameterizedTest(name = "Rename: \"{1}\" > \"{1}2\"")
         @MethodSource("provideHomeData")
@@ -407,7 +406,6 @@ public class BukkitPluginTests {
                     .anyMatch(home -> home.equals(name)));
         }
 
-        // description
         @DisplayName("Test Home Description")
         @ParameterizedTest(name = "Edit Description: \"{1}\"")
         @MethodSource("provideHomeData")
@@ -424,7 +422,6 @@ public class BukkitPluginTests {
             Assertions.assertEquals(description, homeDescription.get());
         }
 
-        // relocate
         @DisplayName("Test Home Relocation")
         @ParameterizedTest(name = "Relocate: \"{1}\"")
         @MethodSource("provideHomeData")
@@ -443,7 +440,6 @@ public class BukkitPluginTests {
             Assertions.assertEquals(newPosition.getZ(), homePosition.get().getZ());
         }
 
-        // overwrite
         @DisplayName("Test Home Overwrite")
         @ParameterizedTest(name = "Overwrite: \"{1}\"")
         @MethodSource("provideHomeData")
@@ -462,7 +458,6 @@ public class BukkitPluginTests {
             Assertions.assertEquals(newPosition.getZ(), homePosition.get().getZ());
         }
 
-        // make public
         @DisplayName("Test Making Home Public")
         @ParameterizedTest(name = "Make Public: \"{1}\"")
         @MethodSource("provideHomeData")
@@ -477,7 +472,6 @@ public class BukkitPluginTests {
             Assertions.assertTrue(plugin.getManager().homes().getPublicHomes().get(owner.getUsername()).contains(name));
         }
 
-        // make private
         @DisplayName("Test Making Home Private")
         @ParameterizedTest(name = "Make Private: \"{1}\"")
         @MethodSource("provideHomeData")
@@ -494,7 +488,6 @@ public class BukkitPluginTests {
                     .contains(name));
         }
 
-        // delete
         @DisplayName("Test Home Deletion")
         @ParameterizedTest(name = "Delete: \"{1}\"")
         @MethodSource("provideHomeData")
@@ -509,7 +502,6 @@ public class BukkitPluginTests {
             plugin.getManager().homes().createHome(owner, name, position);
         }
 
-        // delete all
         @DisplayName("Test Deleting All Homes")
         @Order(9)
         @Test

--- a/common/src/main/java/net/william278/huskhomes/command/EditHomeCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/EditHomeCommand.java
@@ -21,7 +21,6 @@ package net.william278.huskhomes.command;
 
 import de.themoep.minedown.adventure.MineDown;
 import net.william278.huskhomes.HuskHomes;
-import net.william278.huskhomes.config.Locales;
 import net.william278.huskhomes.hook.EconomyHook;
 import net.william278.huskhomes.position.Home;
 import net.william278.huskhomes.user.CommandUser;
@@ -198,11 +197,11 @@ public class EditHomeCommand extends SavedPositionCommand<Home> {
             final String privacy = home.isPublic() ? "public" : "private";
             if (ownerEditing) {
                 plugin.getLocales().getLocale("edit_home_privacy_" + privacy + "_success",
-                                home.getMeta().getName())
+                                home.getName())
                         .ifPresent(executor::sendMessage);
             } else {
                 plugin.getLocales().getLocale("edit_home_privacy_" + privacy + "_success_other",
-                                home.getOwner().getUsername(), home.getMeta().getName())
+                                home.getOwner().getUsername(), home.getName())
                         .ifPresent(executor::sendMessage);
             }
         });
@@ -222,10 +221,10 @@ public class EditHomeCommand extends SavedPositionCommand<Home> {
                                                boolean showTeleportButton, boolean showPrivacyToggleButton) {
         return new ArrayList<>() {{
             if (!otherViewer) {
-                plugin.getLocales().getLocale("edit_home_menu_title", home.getMeta().getName())
+                plugin.getLocales().getLocale("edit_home_menu_title", home.getName())
                         .ifPresent(this::add);
             } else {
-                plugin.getLocales().getLocale("edit_home_menu_title_other", home.getOwner().getUsername(), home.getMeta().getName())
+                plugin.getLocales().getLocale("edit_home_menu_title_other", home.getOwner().getUsername(), home.getName())
                         .ifPresent(this::add);
             }
 
@@ -256,21 +255,17 @@ public class EditHomeCommand extends SavedPositionCommand<Home> {
                             String.format("%.2f", home.getYaw()), String.format("%.2f", home.getPitch()))
                     .ifPresent(this::add);
 
-            final String formattedName = home.getOwner().getUsername() + "." + home.getMeta().getName();
             if (showTeleportButton) {
-                plugin.getLocales().getLocale("edit_home_menu_use_buttons",
-                                formattedName)
+                plugin.getLocales().getLocale("edit_home_menu_use_buttons", home.getSafeIdentifier())
                         .ifPresent(this::add);
             }
-            final String escapedName = Locales.escapeText(formattedName);
-            plugin.getLocales().getRawLocale("edit_home_menu_manage_buttons", escapedName,
+            plugin.getLocales().getRawLocale("edit_home_menu_manage_buttons", home.getSafeIdentifier(),
                             showPrivacyToggleButton ? plugin.getLocales()
                                     .getRawLocale("edit_home_menu_privacy_button_"
-                                            + (home.isPublic() ? "private" : "public"), escapedName)
+                                            + (home.isPublic() ? "private" : "public"), home.getSafeIdentifier())
                                     .orElse("") : "")
                     .map(MineDown::new).ifPresent(this::add);
-            plugin.getLocales().getLocale("edit_home_menu_meta_edit_buttons",
-                            formattedName)
+            plugin.getLocales().getLocale("edit_home_menu_meta_edit_buttons", home.getSafeIdentifier())
                     .ifPresent(this::add);
         }};
     }

--- a/common/src/main/java/net/william278/huskhomes/command/EditWarpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/EditWarpCommand.java
@@ -141,7 +141,7 @@ public class EditWarpCommand extends SavedPositionCommand<Warp> {
     @NotNull
     private List<MineDown> getWarpEditorWindow(@NotNull Warp warp) {
         return new ArrayList<>() {{
-            plugin.getLocales().getLocale("edit_warp_menu_title", warp.getMeta().getName())
+            plugin.getLocales().getLocale("edit_warp_menu_title", warp.getName())
                     .ifPresent(this::add);
 
             plugin.getLocales().getLocale("edit_warp_menu_metadata",
@@ -169,11 +169,11 @@ public class EditWarpCommand extends SavedPositionCommand<Warp> {
                             String.format("%.2f", warp.getYaw()), String.format("%.2f", warp.getPitch()))
                     .ifPresent(this::add);
 
-            plugin.getLocales().getLocale("edit_warp_menu_use_buttons", warp.getMeta().getName())
+            plugin.getLocales().getLocale("edit_warp_menu_use_buttons", warp.getSafeIdentifier())
                     .ifPresent(this::add);
-            plugin.getLocales().getLocale("edit_warp_menu_manage_buttons", warp.getMeta().getName())
+            plugin.getLocales().getLocale("edit_warp_menu_manage_buttons", warp.getSafeIdentifier())
                     .ifPresent(this::add);
-            plugin.getLocales().getLocale("edit_warp_menu_meta_edit_buttons", warp.getMeta().getName())
+            plugin.getLocales().getLocale("edit_warp_menu_meta_edit_buttons", warp.getSafeIdentifier())
                     .ifPresent(this::add);
         }};
     }

--- a/common/src/main/java/net/william278/huskhomes/command/PrivateHomeListCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/PrivateHomeListCommand.java
@@ -108,10 +108,9 @@ public class PrivateHomeListCommand extends ListCommand {
         final PaginatedList homeList = PaginatedList.of(homes.stream().map(home ->
                         plugin.getLocales()
                                 .getRawLocale("home_list_item",
-                                        Locales.escapeText(home.getMeta().getName()),
-                                        home.getOwner().getUsername() + "." + Locales.escapeText(home.getMeta().getName()),
+                                        Locales.escapeText(home.getName()), home.getSafeIdentifier(),
                                         Locales.escapeText(plugin.getLocales().wrapText(home.getMeta().getDescription(), 40)))
-                                .orElse(home.getMeta().getName())).sorted().collect(Collectors.toList()),
+                                .orElse(home.getName())).sorted().collect(Collectors.toList()),
                 plugin.getLocales()
                         .getBaseList(plugin.getSettings().getListItemsPerPage())
                         .setHeaderFormat(plugin.getLocales().getRawLocale("home_list_page_title",

--- a/common/src/main/java/net/william278/huskhomes/command/PublicHomeListCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/PublicHomeListCommand.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 
 public class PublicHomeListCommand extends ListCommand {
 
-
     protected PublicHomeListCommand(@NotNull HuskHomes plugin) {
         super("phomelist", List.of("phomes", "publichomelist"), "[page]", plugin);
     }
@@ -70,8 +69,7 @@ public class PublicHomeListCommand extends ListCommand {
         final PaginatedList homeList = PaginatedList.of(publicHomes.stream().map(home ->
                         plugin.getLocales()
                                 .getRawLocale("public_home_list_item",
-                                        Locales.escapeText(home.getMeta().getName()),
-                                        home.getOwner().getUsername() + "." + Locales.escapeText(home.getMeta().getName()),
+                                        Locales.escapeText(home.getName()), home.getSafeIdentifier(),
                                         Locales.escapeText(home.getOwner().getUsername()),
                                         Locales.escapeText(plugin.getLocales().wrapText(home.getMeta().getDescription(), 40)))
                                 .orElse(home.getName())).sorted().collect(Collectors.toList()),

--- a/common/src/main/java/net/william278/huskhomes/command/SavedPositionCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/SavedPositionCommand.java
@@ -75,9 +75,9 @@ public abstract class SavedPositionCommand<T extends SavedPosition> extends Comm
     public abstract void execute(@NotNull CommandUser executor, @NotNull T position, @NotNull String[] arguments);
 
     private Optional<Home> resolveHome(@NotNull CommandUser executor, @NotNull String homeName) {
-        if (homeName.contains(".")) {
-            final String ownerUsername = homeName.substring(0, homeName.indexOf("."));
-            final String ownerHomeName = homeName.substring(homeName.indexOf(".") + 1);
+        if (homeName.contains(Home.IDENTIFIER_DELIMITER)) {
+            final String ownerUsername = homeName.substring(0, homeName.indexOf(Home.IDENTIFIER_DELIMITER));
+            final String ownerHomeName = homeName.substring(homeName.indexOf(Home.IDENTIFIER_DELIMITER) + 1);
             if (ownerUsername.isBlank() || ownerHomeName.isBlank()) {
                 plugin.getLocales().getLocale("error_invalid_syntax", getUsage())
                         .ifPresent(executor::sendMessage);
@@ -178,7 +178,7 @@ public abstract class SavedPositionCommand<T extends SavedPosition> extends Comm
         if (positionType == Home.class) {
             return switch (args.length) {
                 case 0, 1 -> {
-                    if (args.length == 1 && args[0].contains(".")) {
+                    if (args.length == 1 && args[0].contains(Home.IDENTIFIER_DELIMITER)) {
                         if (executor.hasPermission(getOtherPermission())) {
                             yield filter(plugin.getManager().homes().getUserHomeNames(), args);
                         }

--- a/common/src/main/java/net/william278/huskhomes/command/WarpListCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/WarpListCommand.java
@@ -69,7 +69,7 @@ public class WarpListCommand extends ListCommand {
         final PaginatedList warpList = PaginatedList.of(warps.stream().map(warp ->
                         plugin.getLocales()
                                 .getRawLocale("warp_list_item",
-                                        Locales.escapeText(warp.getName()),
+                                        Locales.escapeText(warp.getName()), warp.getSafeIdentifier(),
                                         Locales.escapeText(plugin.getLocales().wrapText(warp.getMeta().getDescription(), 40)))
                                 .orElse(warp.getName())).sorted().collect(Collectors.toList()),
                 plugin.getLocales()

--- a/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
@@ -172,7 +172,7 @@ public class MySqlDatabase extends Database {
                 Statement.RETURN_GENERATED_KEYS)) {
 
             statement.setInt(1, setPosition(position, connection));
-            statement.setString(2, position.getMeta().getName());
+            statement.setString(2, position.getName());
             statement.setString(3, position.getMeta().getDescription());
             statement.setString(4, position.getMeta().getSerializedTags());
             statement.setTimestamp(5, Timestamp.from(position.getMeta().getCreationTime()));
@@ -205,7 +205,7 @@ public class MySqlDatabase extends Database {
                         `description`=?,
                         `tags`=?
                         WHERE `id`=?;"""))) {
-                    updateStatement.setString(1, position.getMeta().getName());
+                    updateStatement.setString(1, position.getName());
                     updateStatement.setString(2, position.getMeta().getDescription());
                     updateStatement.setString(3, position.getMeta().getSerializedTags());
                     updateStatement.setInt(4, savedPositionId);

--- a/common/src/main/java/net/william278/huskhomes/database/SqLiteDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/SqLiteDatabase.java
@@ -181,7 +181,7 @@ public class SqLiteDatabase extends Database {
                 Statement.RETURN_GENERATED_KEYS)) {
 
             statement.setInt(1, setPosition(position, connection));
-            statement.setString(2, position.getMeta().getName());
+            statement.setString(2, position.getName());
             statement.setString(3, position.getMeta().getDescription());
             statement.setString(4, position.getMeta().getSerializedTags());
             statement.setTimestamp(5, Timestamp.from(position.getMeta().getCreationTime()));
@@ -216,7 +216,7 @@ public class SqLiteDatabase extends Database {
                         `description`=?,
                         `tags`=?
                         WHERE `id`=?;"""))) {
-                    updateStatement.setString(1, position.getMeta().getName());
+                    updateStatement.setString(1, position.getName());
                     updateStatement.setString(2, position.getMeta().getDescription());
                     updateStatement.setString(3, position.getMeta().getSerializedTags());
                     updateStatement.setInt(4, savedPositionId);

--- a/common/src/main/java/net/william278/huskhomes/hook/BlueMapHook.java
+++ b/common/src/main/java/net/william278/huskhomes/hook/BlueMapHook.java
@@ -90,7 +90,7 @@ public class BlueMapHook extends MapHook {
             final String markerId = home.getOwner().getUuid() + ":" + home.getUuid();
             markerSet.remove(markerId);
             markerSet.put(markerId, POIMarker.builder()
-                    .label("/phome " + home.getOwner().getUsername() + "." + home.getName())
+                    .label("/phome " + home.getIdentifier())
                     .position(home.getX(), home.getY(), home.getZ())
                     .maxDistance(5000)
                     .icon(getIcon(PUBLIC_HOME_MARKER_IMAGE_NAME), 25, 25)

--- a/common/src/main/java/net/william278/huskhomes/hook/DynmapHook.java
+++ b/common/src/main/java/net/william278/huskhomes/hook/DynmapHook.java
@@ -94,7 +94,7 @@ public class DynmapHook extends MapHook {
                                 .thumbnail(PUBLIC_HOME_MARKER_IMAGE_NAME)
                                 .field("Owner", home.getOwner().getUsername())
                                 .field("Description", plugin.getLocales().wrapText(home.getMeta().getDescription(), 60))
-                                .field("Command", "/phome " + home.getOwner().getUsername() + "." + home.getName())
+                                .field("Command", "/phome " + home.getIdentifier())
                                 .toHtml());
             });
         });

--- a/common/src/main/java/net/william278/huskhomes/manager/HomesManager.java
+++ b/common/src/main/java/net/william278/huskhomes/manager/HomesManager.java
@@ -65,8 +65,7 @@ public class HomesManager {
     @NotNull
     public List<String> getUserHomeNames() {
         return userHomes.entrySet().stream()
-                .flatMap(e -> e.getValue().stream()
-                        .map(home -> home.getOwner().getUsername() + "." + home.getName()))
+                .flatMap(e -> e.getValue().stream().map(Home::getIdentifier))
                 .toList();
     }
 
@@ -83,7 +82,7 @@ public class HomesManager {
     @NotNull
     public List<String> getPublicHomeNames() {
         return publicHomes.stream()
-                .map(home -> home.getOwner().getUsername() + "." + home.getName())
+                .map(Home::getIdentifier)
                 .toList();
     }
 

--- a/common/src/main/java/net/william278/huskhomes/position/Home.java
+++ b/common/src/main/java/net/william278/huskhomes/position/Home.java
@@ -29,6 +29,7 @@ import java.util.UUID;
  */
 public class Home extends SavedPosition {
 
+    public static final String IDENTIFIER_DELIMITER = ".";
     private final User owner;
     private boolean isPublic;
 
@@ -74,4 +75,17 @@ public class Home extends SavedPosition {
     public void setPublic(boolean aPublic) {
         isPublic = aPublic;
     }
+
+    @NotNull
+    @Override
+    public String getSafeIdentifier() {
+        return getOwner().getUsername() + IDENTIFIER_DELIMITER + super.getSafeIdentifier();
+    }
+
+    @NotNull
+    @Override
+    public String getIdentifier() {
+        return getOwner().getUsername() + IDENTIFIER_DELIMITER + super.getIdentifier();
+    }
+
 }

--- a/common/src/main/java/net/william278/huskhomes/position/SavedPosition.java
+++ b/common/src/main/java/net/william278/huskhomes/position/SavedPosition.java
@@ -19,6 +19,7 @@
 
 package net.william278.huskhomes.position;
 
+import net.william278.huskhomes.config.Locales;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
@@ -79,10 +80,26 @@ public abstract class SavedPosition extends Position implements Comparable<Saved
         return uuid;
     }
 
+    /**
+     * Get the identifier for this position. This is the name, unless the name contains
+     * characters that are not allowed in a command argument, in which case it is the UUID.
+     *
+     * @return The identifier for this position
+     */
+    @NotNull
+    public String getSafeIdentifier() {
+        return Locales.escapeText(getIdentifier()).equals(getIdentifier()) ? getIdentifier() : getUuid().toString();
+    }
+
+    @NotNull
+    public String getIdentifier() {
+        return getName();
+    }
+
     // Compare based on names for alphabetical sorting
     @Override
     public int compareTo(@NotNull SavedPosition o) {
-        return this.getMeta().getName().compareTo(o.getMeta().getName());
+        return this.getName().compareTo(o.getName());
     }
 
     @Override

--- a/common/src/main/java/net/william278/huskhomes/position/SavedPosition.java
+++ b/common/src/main/java/net/william278/huskhomes/position/SavedPosition.java
@@ -88,7 +88,7 @@ public abstract class SavedPosition extends Position implements Comparable<Saved
      */
     @NotNull
     public String getSafeIdentifier() {
-        return Locales.escapeText(getIdentifier()).equals(getIdentifier()) ? getIdentifier() : getUuid().toString();
+        return Locales.escapeText(getName()).equals(getName()) ? getName() : getUuid().toString();
     }
 
     @NotNull

--- a/common/src/main/java/net/william278/huskhomes/util/Validator.java
+++ b/common/src/main/java/net/william278/huskhomes/util/Validator.java
@@ -20,6 +20,7 @@
 package net.william278.huskhomes.util;
 
 import net.william278.huskhomes.HuskHomes;
+import net.william278.huskhomes.position.Home;
 import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("BooleanMethodIsAlwaysInverted")
@@ -43,7 +44,7 @@ public class Validator {
      */
     public boolean isValidName(@NotNull String name) {
         return (isAsciiOnly(name) || plugin.getSettings().doAllowUnicodeNames())
-                && !containsWhitespace(name) && !name.contains(".")
+                && !containsWhitespace(name) && !name.contains(Home.IDENTIFIER_DELIMITER)
                 && name.length() <= MAX_NAME_LENGTH && name.length() >= MIN_NAME_LENGTH;
     }
 

--- a/common/src/main/resources/locales/bg-bg.yml
+++ b/common/src/main/resources/locales/bg-bg.yml
@@ -65,7 +65,7 @@ warp_list_page_title: '[Warps:](#00fb9a) [(%1%-%2% of](#00fb9a) [%3%](#00fb9a bo
 command_list_title: '[HuskHomes](#00fb9a bold) [| Command List](#00fb9a)\n'
 home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:edithome %2%)'
 public_home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7☻ %3%\n&7ℹ %4% run_command=/huskhomes:phome %2%)'
-warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %2% run_command=/huskhomes:warp %1%)'
+warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:warp %2%)'
 command_list_item: '[/%1%](#00fb9a show_text=&7Click to suggest command suggest_command=/%1%)   [%2%](gray show_text=&#00fb9a&/%1%\n&7%3%)'
 list_item_divider: ' [•](gray) '
 list_footer: '\n%1%[Page](#00fb9a) [%2%](#00fb9a)/[%3%](#00fb9a)%4%   %5%'

--- a/common/src/main/resources/locales/de-de.yml
+++ b/common/src/main/resources/locales/de-de.yml
@@ -65,7 +65,7 @@ warp_list_page_title: '[Warps:](#00fb9a) [(%1%-%2% von](#00fb9a) [%3%](#00fb9a b
 command_list_title: '[HuskHomes](#00fb9a bold) [| Befehlsliste](#00fb9a)\n'
 home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:edithome %2%)'
 public_home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7☻ %3%\n&7ℹ %4% run_command=/huskhomes:phome %2%)'
-warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %2% run_command=/huskhomes:warp %1%)'
+warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:warp %2%)'
 command_list_item: '[/%1%](#00fb9a show_text=&7Klicke, um den Befehl im Chat einzufügen command suggest_command=/%1%)   [%2%](gray show_text=&#00fb9a&/%1%\n&7%3%)'
 list_item_divider: ' [•](gray) '
 list_footer: '\n%1%[Seite](#00fb9a) [%2%](#00fb9a)/[%3%](#00fb9a)%4%   %5%'

--- a/common/src/main/resources/locales/en-gb.yml
+++ b/common/src/main/resources/locales/en-gb.yml
@@ -65,7 +65,7 @@ warp_list_page_title: '[Warps:](#00fb9a) [(%1%-%2% of](#00fb9a) [%3%](#00fb9a bo
 command_list_title: '[HuskHomes](#00fb9a bold) [| Command List](#00fb9a)\n'
 home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:edithome %2%)'
 public_home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7☻ %3%\n&7ℹ %4% run_command=/huskhomes:phome %2%)'
-warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %2% run_command=/huskhomes:warp %1%)'
+warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:warp %2%)'
 command_list_item: '[/%1%](#00fb9a show_text=&7Click to suggest command suggest_command=/%1%)   [%2%](gray show_text=&#00fb9a&/%1%\n&7%3%)'
 list_item_divider: ' [•](gray) '
 list_footer: '\n%1%[Page](#00fb9a) [%2%](#00fb9a)/[%3%](#00fb9a)%4%   %5%'

--- a/common/src/main/resources/locales/es-es.yml
+++ b/common/src/main/resources/locales/es-es.yml
@@ -65,7 +65,7 @@ warp_list_page_title: '[Warps:](#00fb9a) [(%1%-%2% of](#00fb9a) [%3%](#00fb9a bo
 command_list_title: '[GreenShield](#green bold) [| lista de comandos](#00fb9a)\n'
 home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:edithome %2%)'
 public_home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7☻ %3%\n&7ℹ %4% run_command=/huskhomes:phome %2%)'
-warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %2% run_command=/huskhomes:warp %1%)'
+warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:warp %2%)'
 command_list_item: '[/%1%](#00fb9a show_text=&7Clic para sugerir el comando suggest_command=/%1%)   [%2%](gray show_text=&#00fb9a&/%1%\n&7%3%)'
 list_item_divider: ' [•](gray) '
 list_footer: '\n%1%[Página](#00fb9a) [%2%](#00fb9a)/[%3%](#00fb9a)%4%   %5%'

--- a/common/src/main/resources/locales/it-it.yml
+++ b/common/src/main/resources/locales/it-it.yml
@@ -65,7 +65,7 @@ warp_list_page_title: '[Lista Warp:](#00fb9a) [(%1%-%2% of](#00fb9a) [%3%](#00fb
 command_list_title: '[HuskHomes](#00fb9a bold) [| Lista comandi](#00fb9a)\n'
 home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:edithome %2%)'
 public_home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7☻ %3%\n&7ℹ %4% run_command=/huskhomes:phome %2%)'
-warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %2% run_command=/huskhomes:warp %1%)'
+warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:warp %2%)'
 command_list_item: '[/%1%](#00fb9a show_text=&7Clicca per usare il comando suggest_command=/%1%)   [%2%](gray show_text=&#00fb9a&/%1%\n&7%3%)'
 list_item_divider: ' [•](gray) '
 list_footer: '\n%1%[Pagina](#00fb9a) [%2%](#00fb9a)/[%3%](#00fb9a)%4%   %5%'

--- a/common/src/main/resources/locales/pl-pl.yml
+++ b/common/src/main/resources/locales/pl-pl.yml
@@ -65,7 +65,7 @@ warp_list_page_title: '[Warps:](#00fb9a) [(%1%-%2% of](#00fb9a) [%3%](#00fb9a bo
 command_list_title: '[HuskHomes](#00fb9a bold) [| Command List](#00fb9a)\n'
 home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:edithome %2%)'
 public_home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7☻ %3%\n&7ℹ %4% run_command=/huskhomes:phome %2%)'
-warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %2% run_command=/huskhomes:warp %1%)'
+warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:warp %2%)'
 command_list_item: '[/%1%](#00fb9a show_text=&7Click to suggest command suggest_command=/%1%)   [%2%](gray show_text=&#00fb9a&/%1%\n&7%3%)'
 list_item_divider: ' [•](gray) '
 list_footer: '\n%1%[Page](#00fb9a) [%2%](#00fb9a)/[%3%](#00fb9a)%4%   %5%'

--- a/common/src/main/resources/locales/tr-tr.yml
+++ b/common/src/main/resources/locales/tr-tr.yml
@@ -65,7 +65,7 @@ warp_list_page_title: '[Warplar:](#00fb9a) [(%1%-%2% of](#00fb9a) [%3%](#00fb9a 
 command_list_title: '[HuskHomes](#00fb9a bold) [| Komut Listesi](#00fb9a)\n'
 home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:edithome %2%)'
 public_home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7☻ %3%\n&7ℹ %4% run_command=/huskhomes:phome %2%)'
-warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %2% run_command=/huskhomes:warp %1%)'
+warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:warp %2%)'
 command_list_item: '[/%1%](#00fb9a show_text=&7Komut önermek için tıklayın suggest_command=/%1%)   [%2%](gray show_text=&#00fb9a&/%1%\n&7%3%)'
 list_item_divider: ' [•](gray) '
 list_footer: '\n%1%[Sayfa](#00fb9a) [%2%](#00fb9a)/[%3%](#00fb9a)%4%   %5%'

--- a/common/src/main/resources/locales/uk-ua.yml
+++ b/common/src/main/resources/locales/uk-ua.yml
@@ -65,7 +65,7 @@ warp_list_page_title: '[Warps:](#00fb9a) [(%1%-%2% of](#00fb9a) [%3%](#00fb9a bo
 command_list_title: '[HuskHomes](#00fb9a bold) [| Command List](#00fb9a)\n'
 home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:edithome %2%)'
 public_home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7☻ %3%\n&7ℹ %4% run_command=/huskhomes:phome %2%)'
-warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %2% run_command=/huskhomes:warp %1%)'
+warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:warp %2%)'
 command_list_item: '[/%1%](#00fb9a show_text=&7Click to suggest command suggest_command=/%1%)   [%2%](gray show_text=&#00fb9a&/%1%\n&7%3%)'
 list_item_divider: ' [•](gray) '
 list_footer: '\n%1%[Page](#00fb9a) [%2%](#00fb9a)/[%3%](#00fb9a)%4%   %5%'

--- a/common/src/main/resources/locales/zh-cn.yml
+++ b/common/src/main/resources/locales/zh-cn.yml
@@ -65,7 +65,7 @@ warp_list_page_title: '[地标:](#00fb9a) [(%1%-%2% 共](#00fb9a) [%3%](#00fb9a 
 command_list_title: '[HuskHomes](#00fb9a bold) [| 指令列表](#00fb9a)\n'
 home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:edithome %2%)'
 public_home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7☻ %3%\n&7ℹ %4% run_command=/huskhomes:phome %2%)'
-warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %2% run_command=/huskhomes:warp %1%)'
+warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:warp %2%)'
 command_list_item: '[/%1%](#00fb9a show_text=&7点击使用命令 suggest_command=/%1%)   [%2%](gray show_text=&#00fb9a&/%1%\n&7%3%)'
 list_item_divider: ' [•](gray) '
 list_footer: '\n%1%[Page](#00fb9a) [%2%](#00fb9a)/[%3%](#00fb9a)%4%   %5%'

--- a/common/src/main/resources/locales/zh-tw.yml
+++ b/common/src/main/resources/locales/zh-tw.yml
@@ -65,7 +65,7 @@ warp_list_page_title: '[地標:](#00fb9a) [(%1%-%2% 共](#00fb9a) [%3%](#00fb9a 
 command_list_title: '[HuskHomes](#00fb9a bold) [| 指令列表](#00fb9a)\n'
 home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:edithome %2%)'
 public_home_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7☻ %3%\n&7ℹ %4% run_command=/huskhomes:phome %2%)'
-warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %2% run_command=/huskhomes:warp %1%)'
+warp_list_item: '[[%1%]](show_text=&#00fb9a&%1%\n&7ℹ %3% run_command=/huskhomes:warp %2%)'
 command_list_item: '[/%1%](#00fb9a show_text=&7點擊使用指令 suggest_command=/%1%)   [%2%](gray show_text=&#00fb9a&/%1%\n&7%3%)'
 list_item_divider: ' [•](gray) '
 list_footer: '\n%1%[頁面](#00fb9a) [%2%](#00fb9a)/[%3%](#00fb9a)%4%   %5%'

--- a/common/src/test/java/net/william278/huskhomes/position/SavedPositionTests.java
+++ b/common/src/test/java/net/william278/huskhomes/position/SavedPositionTests.java
@@ -1,0 +1,88 @@
+package net.william278.huskhomes.position;
+
+import net.william278.huskhomes.user.User;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+@DisplayName("Saved Position Tests")
+public class SavedPositionTests {
+
+    // Map of positions - true if the position contains unsafe characters, false if not
+    private static final Map<String, Boolean> POSITION_UNSAFE_NAMES = Map.of(
+            "TestPosition", false,
+            "ExamplePos", false,
+            "SafeName", false,
+            "[Unsafe]", true,
+            "Unsafe]", true,
+            "[Name](bad)", true,
+            "Unsafe[Name]", true,
+            "不安全(不安全)", true
+    );
+
+    @DisplayName("Test Home Identifiers")
+    @ParameterizedTest(name = "Home: \"{1}\" (Unsafe: {2})")
+    @MethodSource("provideHomeData")
+    public void testHomeIdentifiers(@NotNull Home home, @NotNull @SuppressWarnings("unused") String name, boolean isUnsafeName) {
+        Assertions.assertEquals(
+                home.getIdentifier(),
+                home.getOwner().getUsername() + Home.IDENTIFIER_DELIMITER + home.getName()
+        );
+        Assertions.assertEquals(
+                home.getSafeIdentifier(),
+                isUnsafeName
+                        ? home.getOwner().getUsername() + Home.IDENTIFIER_DELIMITER + home.getUuid()
+                        : home.getIdentifier()
+        );
+    }
+
+    @DisplayName("Test Warp Identifiers")
+    @ParameterizedTest(name = "Warp: \"{1}\" (Unsafe: {2})")
+    @MethodSource("provideWarpData")
+    public void testWarpIdentifiers(@NotNull Warp warp, @NotNull @SuppressWarnings("unused") String name, boolean isUnsafeName) {
+        Assertions.assertEquals(
+                warp.getIdentifier(),
+                warp.getName()
+        );
+        Assertions.assertEquals(
+                warp.getSafeIdentifier(),
+                isUnsafeName ? warp.getUuid().toString() : warp.getIdentifier()
+        );
+    }
+
+    @NotNull
+    private static Stream<Arguments> provideWarpData() {
+        final Position position = Position.at(63.25, 127.43, -32, 180f, -94.3f,
+                World.from("TestWorld", UUID.randomUUID()), "TestServer");
+        return POSITION_UNSAFE_NAMES.entrySet().stream()
+                .map(entry -> Arguments.of(
+                        Warp.from(position, PositionMeta.create(entry.getKey(), "")),
+                        entry.getKey(),
+                        entry.getValue()
+                ));
+    }
+
+    @NotNull
+    private static Stream<Arguments> provideHomeData() {
+        final Position position = Position.at(63.25, 127.43, -32, 180f, -94.3f,
+                World.from("TestWorld", UUID.randomUUID()), "TestServer");
+        return POSITION_UNSAFE_NAMES.entrySet().stream()
+                .map(entry -> Arguments.of(
+                        Home.from(
+                                position,
+                                PositionMeta.create(entry.getKey(), ""),
+                                User.of(UUID.randomUUID(), "TestUser")
+                        ),
+                        entry.getKey(),
+                        entry.getValue()));
+    }
+
+
+}


### PR DESCRIPTION
Fixes #241

This PR adds the ability to resolve homes, public homes and warps by unique ID. If a home cannot be resolved by the passed name, the system will now attempt to resolve the name as a UUID, and if it can, lookup the position by UUID on the database.

This is particularly relevant for overseas users, who have enabled unicode characters in home names, but where players utilise formatting-sensitive characters in home names which must be escaped in the clickable menu syntax.
In the event a position name identifier contains such characters and thus the locale escaped identifier is different from the canonical identifier, the plugin will now supply the position UUID instead of the name.

New valid command inputs: `/home <uuid>`, `/home <owner_name>.<uuid>`, `/phome <uuid>`, `/phome <owner_name>.<uuid>` and `/warp <uuid>`