### PR TITLE
Add setUserLastPosition to API

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
+++ b/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
@@ -94,6 +94,17 @@ public abstract class BaseHuskHomesAPI {
     public CompletableFuture<Optional<Position>> getUserLastPosition(@NotNull User user) {
         return plugin.supplyAsync(() -> plugin.getDatabase().getLastPosition(user));
     }
+    
+    /**
+     * Set the last {@link Position}, as used in the {@code /back} command, for this user
+     *
+     * @param user The {@link User} to set the last position for
+     * @param position The {@link Position} to set as the user's last position
+     * @since 4.2
+     */
+    public void setUserLastPosition(@NotNull User user, @NotNull Position position) {
+        plugin.runAsync(() -> plugin.getDatabase().setLastPosition(user, position));
+    }
 
     /**
      * Returns where the user last disconnected from a server


### PR DESCRIPTION
This PR adds `setUserLastPosition` method to `BaseHuskHomesAPI`.

I specified `Since: 4.2` because I do not know what is the next version.

The method will be used to set user last location on cross-network teleport ([Parties#234](https://github.com/AlessioDP/Parties/issues/234))