### PR TITLE
Add lightweight support for folia via MorePaperLib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
             spigot
             paper
             purpur
+            folia
           game-versions: |
             1.16.5
             1.17.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
             spigot
             paper
             purpur
+            folia
           game-versions: |
             1.16.5
             1.17.1

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ allprojects {
         maven { url 'https://libraries.minecraft.net/' }
         maven { url 'https://api.modrinth.com/maven' }
         maven { url 'https://repo.papermc.io/repository/maven-public/' }
+        maven { url 'https://mvn-repo.arim.space/lesser-gpl3/' }
         maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
         maven { url 'https://repo.spongepowered.org/repository/maven-public/' }
         maven { url 'https://repo.extendedclip.com/content/repositories/placeholderapi/' }

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     compileOnly 'net.william278:Annotaml:2.0.1'
     compileOnly 'net.william278:DesertWell:2.0.2'
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7.1'
-    compileOnly 'com.github.Emibergo02:RedisEconomy:4.0-SNAPSHOT'
+    compileOnly 'com.github.Emibergo02:RedisEconomy:master-SNAPSHOT'
     compileOnly 'me.clip:placeholderapi:2.11.3'
 
     testImplementation 'com.github.seeseemelk:MockBukkit-v1.16:1.5.2'

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 
     implementation 'org.bstats:bstats-bukkit:3.0.2'
     implementation 'io.papermc:paperlib:1.0.8'
+    implementation 'space.arim.morepaperlib:morepaperlib:0.4.2'
     implementation 'me.lucko:commodore:2.2'
     implementation 'net.kyori:adventure-platform-bukkit:4.3.0'
 
@@ -46,5 +47,6 @@ shadowJar {
     relocate 'net.kyori', 'net.william278.huskhomes.libraries'
     relocate 'org.bstats', 'net.william278.huskhomes.libraries.bstats'
     relocate 'io.papermc.lib', 'net.william278.huskhomes.libraries.paperlib'
+    relocate 'space.arim.morepaperlib', 'net.william278.huskhomes.libraries.paperlib'
     relocate 'me.lucko.commodore', 'net.william278.huskhomes.libraries.commodore'
 }

--- a/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
@@ -62,11 +62,15 @@ import org.bukkit.plugin.java.JavaPluginLoader;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import space.arim.morepaperlib.MorePaperLib;
+import space.arim.morepaperlib.scheduling.GracefulScheduling;
+import space.arim.morepaperlib.scheduling.ScheduledTask;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -76,6 +80,7 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes, BukkitTask
      * Metrics ID for <a href="https://bstats.org/plugin/bukkit/HuskHomes/8430">HuskHomes on Bukkit</a>.
      */
     private static final int METRICS_ID = 8430;
+    private ConcurrentHashMap<Integer, ScheduledTask> tasks;
     private Set<SavedUser> savedUsers;
     private Settings settings;
     private Locales locales;
@@ -94,6 +99,7 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes, BukkitTask
     @Nullable
     private Broker broker;
     private BukkitAudiences audiences;
+    private MorePaperLib paperLib;
 
     private static BukkitHuskHomes instance;
 
@@ -122,6 +128,8 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes, BukkitTask
     public void onEnable() {
         // Create adventure audience
         this.audiences = BukkitAudiences.create(this);
+        this.paperLib = new MorePaperLib(this);
+        this.tasks = new ConcurrentHashMap<>();
         this.savedUsers = new HashSet<>();
         this.globalPlayerList = new HashMap<>();
         this.currentlyOnWarmup = new HashSet<>();
@@ -462,8 +470,19 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes, BukkitTask
 
     @Override
     @NotNull
+    public GracefulScheduling getScheduler() {
+        return paperLib.scheduling();
+    }
+
+    @Override
+    @NotNull
+    public ConcurrentHashMap<Integer, ScheduledTask> getTasks() {
+        return tasks;
+    }
+
+    @Override
+    @NotNull
     public HuskHomes getPlugin() {
         return this;
     }
-
 }

--- a/common/src/main/java/net/william278/huskhomes/util/TaskRunner.java
+++ b/common/src/main/java/net/william278/huskhomes/util/TaskRunner.java
@@ -26,13 +26,22 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 public interface TaskRunner {
+
     int runAsync(@NotNull Runnable runnable);
+
     <T> CompletableFuture<T> supplyAsync(@NotNull Supplier<T> supplier);
+
     void runSync(@NotNull Runnable runnable);
+
     int runAsyncRepeating(@NotNull Runnable runnable, long delay);
+
     void runLater(@NotNull Runnable runnable, long delay);
+
     void cancelTask(int taskId);
+
     void cancelAllTasks();
+
     @NotNull
     HuskHomes getPlugin();
+
 }

--- a/paper/build.gradle
+++ b/paper/build.gradle
@@ -42,6 +42,7 @@ shadowJar {
     relocate 'net.kyori', 'net.william278.huskhomes.libraries'
     relocate 'org.bstats', 'net.william278.huskhomes.libraries.bstats'
     relocate 'io.papermc.lib', 'net.william278.huskhomes.libraries.paperlib'
+    relocate 'space.arim.morepaperlib', 'net.william278.huskhomes.libraries.paperlib'
     relocate 'me.lucko.commodore', 'net.william278.huskhomes.libraries.commodore'
 }
 

--- a/paper/src/main/resources/paper-plugin.yml
+++ b/paper/src/main/resources/paper-plugin.yml
@@ -6,6 +6,7 @@ main: 'net.william278.huskhomes.PaperHuskHomes'
 loader: 'net.william278.huskhomes.PaperHuskHomesLoader'
 version: '${version}'
 api-version: 1.19
+folia-supported: true
 dependencies:
   - name: Vault
     required: false


### PR DESCRIPTION
Supersedes #372, Closes #342

Adds support for Folia. Uses [MorePaperLib](https://github.com/A248/MorePaperLib) for platform-dependent accurate scheduling rather than a manual implementation.