### PR TITLE
Fix invalid warp locale not displaying, make home/warp lookup case-insensitive

### DIFF
--- a/bukkit/src/test/java/net/william278/huskhomes/BukkitPluginTests.java
+++ b/bukkit/src/test/java/net/william278/huskhomes/BukkitPluginTests.java
@@ -330,8 +330,24 @@ public class BukkitPluginTests {
             Assertions.assertTrue(plugin.getDatabase().getWarp(name).isPresent());
         }
 
+        @DisplayName("Test Querying Warps Case-Insensitively")
+        @ParameterizedTest(name = "Query: \"{0}\"")
+        @MethodSource("provideWarpData")
+        @Order(8)
+        public void testWarpCaseInsensitiveQuery(@NotNull String name, @SuppressWarnings("unused") @NotNull Position position) {
+            final String nameUpper = name.toUpperCase();
+            final Optional<Warp> nameUpperWarp = plugin.getDatabase().getWarp(nameUpper);
+            Assertions.assertTrue(nameUpperWarp.isPresent());
+            Assertions.assertEquals(name, nameUpperWarp.get().getName());
+
+            final String nameLower = name.toLowerCase();
+            final Optional<Warp> nameLowerWarp = plugin.getDatabase().getWarp(nameLower);
+            Assertions.assertTrue(nameLowerWarp.isPresent());
+            Assertions.assertEquals(name, nameLowerWarp.get().getName());
+        }
+
         @DisplayName("Test Deleting All Warps")
-        @Order(7)
+        @Order(9)
         @Test
         public void testWarpDeleteAll() {
             final int deleted = plugin.getManager().warps().deleteAllWarps();
@@ -488,10 +504,26 @@ public class BukkitPluginTests {
                     .contains(name));
         }
 
+        @DisplayName("Test Querying Homes Case-Insensitively")
+        @ParameterizedTest(name = "Query: \"{1}\"")
+        @MethodSource("provideHomeData")
+        @Order(8)
+        public void testWarpCaseInsensitiveQuery(@NotNull OnlineUser owner, @NotNull String name, @SuppressWarnings("unused") @NotNull Position position) {
+            final String nameUpper = name.toUpperCase();
+            final Optional<Home> nameUpperWarp = plugin.getDatabase().getHome(owner, nameUpper);
+            Assertions.assertTrue(nameUpperWarp.isPresent());
+            Assertions.assertEquals(name, nameUpperWarp.get().getName());
+
+            final String nameLower = name.toLowerCase();
+            final Optional<Home> nameLowerWarp = plugin.getDatabase().getHome(owner, nameLower);
+            Assertions.assertTrue(nameLowerWarp.isPresent());
+            Assertions.assertEquals(name, nameLowerWarp.get().getName());
+        }
+
         @DisplayName("Test Home Deletion")
         @ParameterizedTest(name = "Delete: \"{1}\"")
         @MethodSource("provideHomeData")
-        @Order(8)
+        @Order(9)
         public void testHomeDeletion(@NotNull OnlineUser owner, @NotNull String name, @SuppressWarnings("unused") @NotNull Position position) {
             plugin.getManager().homes().deleteHome(owner, name);
             Assertions.assertFalse(plugin.getDatabase().getHome(owner, name).isPresent());
@@ -503,7 +535,7 @@ public class BukkitPluginTests {
         }
 
         @DisplayName("Test Deleting All Homes")
-        @Order(9)
+        @Order(10)
         @Test
         public void testDeleteAllHomes() {
             final int deleted = plugin.getManager().homes().deleteAllHomes(homeOwner);

--- a/common/src/main/java/net/william278/huskhomes/command/SavedPositionCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/SavedPositionCommand.java
@@ -132,7 +132,7 @@ public abstract class SavedPositionCommand<T extends SavedPosition> extends Comm
     private Optional<Warp> resolveWarp(@NotNull CommandUser executor, @NotNull String warpName) {
         final Optional<Warp> warp = resolveWarpByName(warpName);
         if (warp.isEmpty()) {
-            plugin.getLocales().getLocale("error_home_invalid", warpName)
+            plugin.getLocales().getLocale("error_warp_invalid", warpName)
                     .ifPresent(executor::sendMessage);
             return Optional.empty();
         }

--- a/common/src/main/java/net/william278/huskhomes/command/SavedPositionCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/SavedPositionCommand.java
@@ -131,8 +131,13 @@ public abstract class SavedPositionCommand<T extends SavedPosition> extends Comm
 
     private Optional<Warp> resolveWarp(@NotNull CommandUser executor, @NotNull String warpName) {
         final Optional<Warp> warp = resolveWarpByName(warpName);
-        if (warp.isPresent() && executor instanceof OnlineUser user && plugin.getSettings().doPermissionRestrictWarps()
-            && (!user.hasPermission(Warp.getWildcardPermission()) && !user.hasPermission(Warp.getPermission(warpName)))) {
+        if (warp.isEmpty()) {
+            plugin.getLocales().getLocale("error_home_invalid", warpName)
+                    .ifPresent(executor::sendMessage);
+            return Optional.empty();
+        }
+        if (executor instanceof OnlineUser user && plugin.getSettings().doPermissionRestrictWarps()
+            && !user.hasPermission(Warp.getWildcardPermission()) && !user.hasPermission(Warp.getPermission(warpName))) {
             plugin.getLocales().getLocale("error_warp_invalid", warpName)
                     .ifPresent(executor::sendMessage);
             return Optional.empty();

--- a/common/src/main/java/net/william278/huskhomes/config/Settings.java
+++ b/common/src/main/java/net/william278/huskhomes/config/Settings.java
@@ -137,6 +137,9 @@ public class Settings {
     @YamlKey("general.strict_tpa_here_requests")
     private boolean strictTpaHereRequests = true;
 
+    @YamlKey("general.case_insensitive_names")
+    private boolean caseInsensitiveNames = true;
+
     @YamlKey("general.allow_unicode_names")
     private boolean allowUnicodeNames = false;
 
@@ -360,6 +363,8 @@ public class Settings {
     public boolean doStrictTpaHereRequests() {
         return strictTpaHereRequests;
     }
+
+    public boolean caseInsensitiveNames() { return caseInsensitiveNames; }
 
     public boolean doAllowUnicodeNames() {
         return allowUnicodeNames;

--- a/common/src/main/java/net/william278/huskhomes/database/Database.java
+++ b/common/src/main/java/net/william278/huskhomes/database/Database.java
@@ -208,13 +208,26 @@ public abstract class Database {
     }
 
     /**
-     * Get a {@link Home} set by a {@link User}
+     * Get a {@link Home} with the given name, set by the given {@link User}
      *
      * @param user     The {@link User} who set the home
-     * @param homeName The <i>case-insensitive</i> name of the home to get
+     * @param homeName The name of the home to get
+     * @return A future returning an optional with the {@link Home} present if it exists
+     * @apiNote Whether the name lookup query is case-insensitive is determined by the {@code general.case_insensitive_names} setting
+     */
+    public final Optional<Home> getHome(@NotNull User user, @NotNull String homeName) {
+        return this.getHome(user, homeName, plugin.getSettings().caseInsensitiveNames());
+    }
+
+    /**
+     * Get a {@link Home} with the given name, set by the given {@link User}
+     *
+     * @param user            The {@link User} who set the home
+     * @param homeName        The name of the home to get
+     * @param caseInsensitive Whether the name lookup query should be case-insensitive
      * @return A future returning an optional with the {@link Home} present if it exists
      */
-    public abstract Optional<Home> getHome(@NotNull User user, @NotNull String homeName);
+    protected abstract Optional<Home> getHome(@NotNull User user, @NotNull String homeName, boolean caseInsensitive);
 
     /**
      * Get a {@link Home} by its unique id
@@ -225,12 +238,24 @@ public abstract class Database {
     public abstract Optional<Home> getHome(@NotNull UUID uuid);
 
     /**
-     * Get a {@link Warp} with the given name (<i>case-insensitive</i>)
+     * Get a {@link Warp} with the given name
      *
-     * @param warpName The <i>case-insensitive</i> name of the warp to get
+     * @param warpName The name of the warp to get
+     * @return A future returning an optional with the {@link Warp} present if it exists
+     * @apiNote Whether the name lookup query is case-insensitive is determined by the {@code general.case_insensitive_names} setting
+     */
+    public final Optional<Warp> getWarp(@NotNull String warpName) {
+        return getWarp(warpName, plugin.getSettings().caseInsensitiveNames());
+    }
+
+    /**
+     * Get a {@link Warp} with the given name
+     *
+     * @param warpName        The name of the warp to get
+     * @param caseInsensitive Whether the search should be case-insensitive
      * @return A future returning an optional with the {@link Warp} present if it exists
      */
-    public abstract Optional<Warp> getWarp(@NotNull String warpName);
+    protected abstract Optional<Warp> getWarp(@NotNull String warpName, boolean caseInsensitive);
 
     /**
      * Get a {@link Warp} by its unique id

--- a/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
@@ -427,7 +427,7 @@ public class MySqlDatabase extends Database {
                     INNER JOIN `%positions_table%` ON `%saved_positions_table%`.`position_id`=`%positions_table%`.`id`
                     INNER JOIN `%players_table%` ON `%homes_table%`.`owner_uuid`=`%players_table%`.`uuid`
                     WHERE `owner_uuid`=?
-                    AND `name`=?;"""))) {
+                    AND UPPER(`name`) LIKE UPPER(?);"""))) {
                 statement.setString(1, user.getUuid().toString());
                 statement.setString(2, homeName);
 
@@ -502,7 +502,7 @@ public class MySqlDatabase extends Database {
                     FROM `%warps_table%`
                     INNER JOIN `%saved_positions_table%` ON `%warps_table%`.`saved_position_id`=`%saved_positions_table%`.`id`
                     INNER JOIN `%positions_table%` ON `%saved_positions_table%`.`position_id`=`%positions_table%`.`id`
-                    WHERE `name`=?;"""))) {
+                    WHERE UPPER(`name`) LIKE UPPER(?);"""))) {
                 statement.setString(1, warpName);
 
                 final ResultSet resultSet = statement.executeQuery();

--- a/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
@@ -418,7 +418,7 @@ public class MySqlDatabase extends Database {
     }
 
     @Override
-    public Optional<Home> getHome(@NotNull User user, @NotNull String homeName) {
+    public Optional<Home> getHome(@NotNull User user, @NotNull String homeName, boolean caseInsensitive) {
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     SELECT `%homes_table%`.`uuid` AS `home_uuid`, `owner_uuid`, `username` AS `owner_username`, `name`, `description`, `tags`, `timestamp`, `x`, `y`, `z`, `yaw`, `pitch`, `world_name`, `world_uuid`, `server_name`, `public`
@@ -427,7 +427,7 @@ public class MySqlDatabase extends Database {
                     INNER JOIN `%positions_table%` ON `%saved_positions_table%`.`position_id`=`%positions_table%`.`id`
                     INNER JOIN `%players_table%` ON `%homes_table%`.`owner_uuid`=`%players_table%`.`uuid`
                     WHERE `owner_uuid`=?
-                    AND UPPER(`name`) LIKE UPPER(?);"""))) {
+                    """ + (caseInsensitive ? "AND UPPER(`name`) LIKE UPPER(?);" : "AND `name`=?;")))) {
                 statement.setString(1, user.getUuid().toString());
                 statement.setString(2, homeName);
 
@@ -495,14 +495,14 @@ public class MySqlDatabase extends Database {
     }
 
     @Override
-    public Optional<Warp> getWarp(@NotNull String warpName) {
+    public Optional<Warp> getWarp(@NotNull String warpName, boolean caseInsensitive) {
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     SELECT `%warps_table%`.`uuid` AS `warp_uuid`, `name`, `description`, `tags`, `timestamp`, `x`, `y`, `z`, `yaw`, `pitch`, `world_name`, `world_uuid`, `server_name`
                     FROM `%warps_table%`
                     INNER JOIN `%saved_positions_table%` ON `%warps_table%`.`saved_position_id`=`%saved_positions_table%`.`id`
                     INNER JOIN `%positions_table%` ON `%saved_positions_table%`.`position_id`=`%positions_table%`.`id`
-                    WHERE UPPER(`name`) LIKE UPPER(?);"""))) {
+                    """ + (caseInsensitive ? "WHERE UPPER(`name`) LIKE UPPER(?);" : "WHERE `name`=?;")))) {
                 statement.setString(1, warpName);
 
                 final ResultSet resultSet = statement.executeQuery();
@@ -991,7 +991,6 @@ public class MySqlDatabase extends Database {
 
     @Override
     public int deleteAllWarps() {
-
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     DELETE FROM `%positions_table%`

--- a/common/src/main/java/net/william278/huskhomes/database/SqLiteDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/SqLiteDatabase.java
@@ -429,7 +429,7 @@ public class SqLiteDatabase extends Database {
     }
 
     @Override
-    public Optional<Home> getHome(@NotNull User user, @NotNull String homeName) {
+    public Optional<Home> getHome(@NotNull User user, @NotNull String homeName, boolean caseInsensitive) {
         try {
             try (PreparedStatement statement = getConnection().prepareStatement(formatStatementTables("""
                     SELECT `%homes_table%`.`uuid` AS `home_uuid`, `owner_uuid`, `username` AS `owner_username`, `name`, `description`, `tags`, `timestamp`, `x`, `y`, `z`, `yaw`, `pitch`, `world_name`, `world_uuid`, `server_name`, `public`
@@ -438,7 +438,7 @@ public class SqLiteDatabase extends Database {
                     INNER JOIN `%positions_table%` ON `%saved_positions_table%`.`position_id`=`%positions_table%`.`id`
                     INNER JOIN `%players_table%` ON `%homes_table%`.`owner_uuid`=`%players_table%`.`uuid`
                     WHERE `owner_uuid`=?
-                    AND UPPER(`name`) LIKE UPPER(?);"""))) {
+                    """ + (caseInsensitive ? "AND UPPER(`name`) LIKE UPPER(?);" : "AND `name`=?;")))) {
                 statement.setString(1, user.getUuid().toString());
                 statement.setString(2, homeName);
 
@@ -506,14 +506,14 @@ public class SqLiteDatabase extends Database {
     }
 
     @Override
-    public Optional<Warp> getWarp(@NotNull String warpName) {
+    public Optional<Warp> getWarp(@NotNull String warpName, boolean caseInsensitive) {
         try {
             try (PreparedStatement statement = getConnection().prepareStatement(formatStatementTables("""
                     SELECT `%warps_table%`.`uuid` AS `warp_uuid`, `name`, `description`, `tags`, `timestamp`, `x`, `y`, `z`, `yaw`, `pitch`, `world_name`, `world_uuid`, `server_name`
                     FROM `%warps_table%`
                     INNER JOIN `%saved_positions_table%` ON `%warps_table%`.`saved_position_id`=`%saved_positions_table%`.`id`
                     INNER JOIN `%positions_table%` ON `%saved_positions_table%`.`position_id`=`%positions_table%`.`id`
-                    WHERE UPPER(`name`) LIKE UPPER(?);"""))) {
+                    """ + (caseInsensitive ? "WHERE UPPER(`name`) LIKE UPPER(?);" : "WHERE `name`=?;")))) {
                 statement.setString(1, warpName);
 
                 final ResultSet resultSet = statement.executeQuery();

--- a/common/src/main/java/net/william278/huskhomes/database/SqLiteDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/SqLiteDatabase.java
@@ -438,7 +438,7 @@ public class SqLiteDatabase extends Database {
                     INNER JOIN `%positions_table%` ON `%saved_positions_table%`.`position_id`=`%positions_table%`.`id`
                     INNER JOIN `%players_table%` ON `%homes_table%`.`owner_uuid`=`%players_table%`.`uuid`
                     WHERE `owner_uuid`=?
-                    AND `name`=?;"""))) {
+                    AND UPPER(`name`) LIKE UPPER(?);"""))) {
                 statement.setString(1, user.getUuid().toString());
                 statement.setString(2, homeName);
 
@@ -513,7 +513,7 @@ public class SqLiteDatabase extends Database {
                     FROM `%warps_table%`
                     INNER JOIN `%saved_positions_table%` ON `%warps_table%`.`saved_position_id`=`%saved_positions_table%`.`id`
                     INNER JOIN `%positions_table%` ON `%saved_positions_table%`.`position_id`=`%positions_table%`.`id`
-                    WHERE `name`=?;"""))) {
+                    WHERE UPPER(`name`) LIKE UPPER(?);"""))) {
                 statement.setString(1, warpName);
 
                 final ResultSet resultSet = statement.executeQuery();

--- a/common/src/main/java/net/william278/huskhomes/manager/HomesManager.java
+++ b/common/src/main/java/net/william278/huskhomes/manager/HomesManager.java
@@ -186,6 +186,7 @@ public class HomesManager {
 
         final Home home = existingHome
                 .map(existing -> {
+                    existing.getMeta().setName(name);
                     existing.update(position);
                     return existing;
                 })

--- a/common/src/main/java/net/william278/huskhomes/manager/WarpsManager.java
+++ b/common/src/main/java/net/william278/huskhomes/manager/WarpsManager.java
@@ -124,13 +124,8 @@ public class WarpsManager {
 
         final Warp warp = existingWarp
                 .map(existing -> {
-                    existing.setX(position.getX());
-                    existing.setY(position.getY());
-                    existing.setZ(position.getZ());
-                    existing.setWorld(position.getWorld());
-                    existing.setServer(position.getServer());
-                    existing.setYaw(position.getYaw());
-                    existing.setPitch(position.getPitch());
+                    existing.getMeta().setName(name);
+                    existing.update(position);
                     return existing;
                 })
                 .orElse(Warp.from(position, PositionMeta.create(name, "")));


### PR DESCRIPTION
Closes #379

Fixes a missing locale when trying to teleport to an invalid warp, and makes the database querying for homes/warps case-insensitive.