### PR TITLE
Added the ability to random teleport to another world

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -74,7 +74,7 @@ public class RtpCommand extends Command implements UserListTabProvider {
     @Override
     public List<String> suggest(@NotNull CommandUser user, @NotNull String[] args) {
         return switch (args.length) {
-            case 0, 1 -> user.hasPermission("other") ? UserListTabProvider.super.suggestLocal(user, args)
+            case 0, 1 -> user.hasPermission("other") ? UserListTabProvider.super.suggestLocal(args)
                     : user instanceof OnlineUser online ? List.of(online.getUsername()) : List.of();
             case 2 -> user.hasPermission("world") ? plugin.getWorlds().stream().map(World::getName).toList()
                     : List.of();

--- a/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/RtpCommand.java
@@ -21,6 +21,7 @@ package net.william278.huskhomes.command;
 
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.hook.EconomyHook;
+import net.william278.huskhomes.position.World;
 import net.william278.huskhomes.teleport.Teleport;
 import net.william278.huskhomes.teleport.TeleportBuilder;
 import net.william278.huskhomes.teleport.TeleportationException;
@@ -28,6 +29,7 @@ import net.william278.huskhomes.user.CommandUser;
 import net.william278.huskhomes.user.OnlineUser;
 import net.william278.huskhomes.user.SavedUser;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -35,12 +37,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class RtpCommand extends Command {
+public class RtpCommand extends Command implements UserListTabProvider {
 
     protected RtpCommand(@NotNull HuskHomes plugin) {
-        super("rtp", List.of(), "[player]", plugin);
+        super("rtp", List.of(), "[player] [world]", plugin);
         addAdditionalPermissions(Map.of(
                 "other", true,
+                "world", true,
                 "bypass_cooldown", true
         ));
     }
@@ -61,47 +64,85 @@ public class RtpCommand extends Command {
             return;
         }
 
+        // Validate, then execute the RTP
         final OnlineUser teleporter = optionalTeleporter.get();
+        this.validateRtp(teleporter, executor, args.length > 1 ? removeFirstArg(args) : args)
+                .ifPresent(world -> this.executeRtp(teleporter, executor, world, args));
+    }
+
+    @Nullable
+    @Override
+    public List<String> suggest(@NotNull CommandUser user, @NotNull String[] args) {
+        return switch (args.length) {
+            case 0, 1 -> user.hasPermission("other") ? UserListTabProvider.super.suggestLocal(user, args)
+                    : user instanceof OnlineUser online ? List.of(online.getUsername()) : List.of();
+            case 2 -> user.hasPermission("world") ? plugin.getWorlds().stream().map(World::getName).toList()
+                    : List.of();
+            default -> null;
+        };
+    }
+
+    // Validates the RTP command, returning the world to randomly teleport in if successful
+    private Optional<World> validateRtp(@NotNull OnlineUser teleporter, @NotNull CommandUser executor, @NotNull String[] args) {
+        // Check permissions if the user is being teleported by another player
         if (!executor.equals(teleporter) && !executor.hasPermission(getPermission("other"))) {
             plugin.getLocales().getLocale("error_no_permission")
                     .ifPresent(executor::sendMessage);
-            return;
+            return Optional.empty();
         }
 
-        this.executeRtp(teleporter, executor, args);
-    }
-
-    private void executeRtp(@NotNull OnlineUser teleporter, @NotNull CommandUser executor, @NotNull String[] args) {
+        // Check they have sufficient funds
         if (!plugin.validateEconomyCheck(teleporter, EconomyHook.Action.RANDOM_TELEPORT)) {
-            return;
+            return Optional.empty();
         }
 
+        // Determine the world to carry out the RTP in
+        final World teleporterWorld = teleporter.getPosition().getWorld();
+        final Optional<World> optionalWorld = args.length >= 1 ? plugin.getWorlds().stream().filter(w -> w.getName()
+                .equalsIgnoreCase(args[0])).findFirst() : Optional.of(teleporterWorld);
+        if (optionalWorld.isEmpty()) {
+            plugin.getLocales().getLocale("error_invalid_world", args[0])
+                    .ifPresent(executor::sendMessage);
+            return Optional.empty();
+        }
+
+        // Ensure the user has permission to randomly teleport in the world
+        final World world = optionalWorld.get();
+        if (!world.equals(teleporterWorld) && !executor.hasPermission(getPermission("world"))) {
+            plugin.getLocales().getLocale("error_no_permission")
+                    .ifPresent(executor::sendMessage);
+            return Optional.empty();
+        }
         if (plugin.getSettings().getRtpRestrictedWorlds().stream()
-                .anyMatch(worldName -> worldName.equals(teleporter.getPosition().getWorld().getName()))) {
+                .anyMatch(worldName -> worldName.equals(world.getName()))) {
             plugin.getLocales().getLocale("error_rtp_restricted_world")
                     .ifPresent(executor::sendMessage);
-            return;
+            return Optional.empty();
         }
 
-        plugin.editUserData(teleporter, (SavedUser user) -> {
-
-        });
+        // Check they are not on random teleport cooldown
         final SavedUser user = plugin.getSavedUser(teleporter)
                 .orElseThrow(() -> new IllegalStateException("No user data found for " + teleporter.getUsername()));
         final Instant currentTime = Instant.now();
         if (executor.equals(teleporter) && !currentTime.isAfter(user.getRtpCooldown()) &&
                 !executor.hasPermission(getPermission("bypass_cooldown"))) {
-            plugin.getLocales().getLocale("error_rtp_cooldown",
-                            Long.toString(currentTime.until(user.getRtpCooldown(), ChronoUnit.MINUTES) + 1))
-                    .ifPresent(executor::sendMessage);
-            return;
+            plugin.getLocales().getLocale("error_rtp_cooldown", Long.toString(
+                    currentTime.until(user.getRtpCooldown(), ChronoUnit.MINUTES) + 1)
+            ).ifPresent(executor::sendMessage);
+            return Optional.empty();
         }
 
+        return Optional.of(world);
+    }
+
+    // Executes the random teleport
+    private void executeRtp(@NotNull OnlineUser teleporter, @NotNull CommandUser executor, @NotNull World world,
+                            @NotNull String[] args) {
         // Generate a random position
         plugin.getLocales().getLocale("teleporting_random_generation")
                 .ifPresent(teleporter::sendMessage);
         plugin.getRandomTeleportEngine()
-                .getRandomPosition(teleporter.getPosition().getWorld(), args.length > 1 ? removeFirstArg(args) : args)
+                .getRandomPosition(world, args.length > 1 ? removeFirstArg(args) : args)
                 .thenAccept(position -> {
                     if (position.isEmpty()) {
                         plugin.getLocales().getLocale("error_rtp_randomization_timeout")
@@ -109,6 +150,7 @@ public class RtpCommand extends Command {
                         return;
                     }
 
+                    // Build and execute the teleport
                     final TeleportBuilder builder = Teleport.builder(plugin)
                             .teleporter(teleporter)
                             .target(position.get());
@@ -123,6 +165,7 @@ public class RtpCommand extends Command {
                         return;
                     }
 
+                    // Update their RTP cooldown
                     plugin.editUserData(teleporter, (SavedUser saved) -> saved.setRtpCooldown(Instant.now()
                             .plus(plugin.getSettings().getRtpCooldownLength(), ChronoUnit.MINUTES)));
                 });

--- a/common/src/main/java/net/william278/huskhomes/command/UserListTabProvider.java
+++ b/common/src/main/java/net/william278/huskhomes/command/UserListTabProvider.java
@@ -35,7 +35,7 @@ public interface UserListTabProvider extends TabProvider {
     }
 
     @Nullable
-    default List<String> suggestLocal(@NotNull CommandUser user, @NotNull String[] args) {
+    default List<String> suggestLocal(@NotNull String[] args) {
         return args.length < 2 ? getPlugin().getLocalPlayerList(false) : null;
     }
 

--- a/common/src/main/java/net/william278/huskhomes/command/UserListTabProvider.java
+++ b/common/src/main/java/net/william278/huskhomes/command/UserListTabProvider.java
@@ -34,6 +34,11 @@ public interface UserListTabProvider extends TabProvider {
         return args.length < 2 ? getPlugin().getPlayerList(false) : null;
     }
 
+    @Nullable
+    default List<String> suggestLocal(@NotNull CommandUser user, @NotNull String[] args) {
+        return args.length < 2 ? getPlugin().getLocalPlayerList(false) : null;
+    }
+
     @NotNull
     HuskHomes getPlugin();
 

--- a/common/src/main/java/net/william278/huskhomes/random/RandomTeleportEngine.java
+++ b/common/src/main/java/net/william278/huskhomes/random/RandomTeleportEngine.java
@@ -53,16 +53,24 @@ public abstract class RandomTeleportEngine {
     }
 
     /**
-     * Get the origin position (spawn) of this server
+     * Get the origin (center) position for the world
      *
+     * @param world The world to get the origin position for
      * @return The origin position
+     * @implNote This will return the {@link HuskHomes#getServerSpawn() server spawn position} if it is in the same
+     * world as the world passed to this method, otherwise it will return a position at 0, 128, 0 on the provided world.
      */
     @NotNull
     protected Position getCenterPoint(@NotNull World world) {
         return plugin.getServerSpawn()
-                .map(s -> s.getPosition(plugin.getServerName()))
-                .orElse(Position.at(0d, 128d, 0d, 0f, 0f,
-                        world, plugin.getServerName()));
+                .map(spawn -> spawn.getPosition(plugin.getServerName()))
+                .flatMap(position -> {
+                    if (position.getWorld().equals(world)) {
+                        return Optional.of(position);
+                    }
+                    return Optional.empty();
+                })
+                .orElse(Position.at(0d, 128d, 0d, world, plugin.getServerName()));
     }
 
     /**

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -1,7 +1,10 @@
-HuskHomes provides a range of commands for you to use. This page will detail the permissions for each command to [let you manage access](managing-access) to the plugin's different features.
+HuskHomes provides a range of commands for you to use. This page will detail the permissions for each command
+to [let you manage access](managing-access) to the plugin's different features.
 
 ## Commands & Permissions Table
-This is a table of HuskHomes' commands and their required permission nodes. Additional permissions provided by the plugin to control other variables are detailed further below!
+
+This is a table of HuskHomes' commands and their required permission nodes. Additional permissions provided by the
+plugin to control other variables are detailed further below!
 
 | Command                                                         | Aliases                      | Description                                         | Base Permission&dagger;       |
 |-----------------------------------------------------------------|------------------------------|-----------------------------------------------------|-------------------------------|
@@ -23,7 +26,7 @@ This is a table of HuskHomes' commands and their required permission nodes. Addi
 | `/tpahere <player>`                                             |                              | Request another player to teleport to you           | `huskhomes.command.tpahere`   |
 | `/tpaccept [player]`                                            | `/tpyes`                     | Accept a teleport request                           | `huskhomes.command.tpaccept`  |
 | `/tpdecline [player]`                                           | `/tpdeny`, `/tpno`           | Decline a teleport request                          | `huskhomes.command.tpdecline` |
-| `/rtp [player]`                                                 |                              | Teleport randomly into the wild                     | `huskhomes.command.rtp`       |
+| `/rtp [player] [world]`                                         |                              | Teleport randomly into the wild                     | `huskhomes.command.rtp`       |
 | `/tpignore`                                                     |                              | Ignore incoming teleport requests                   | `huskhomes.command.tpignore`  |
 | `/tpoffline <player>`                                           |                              | Teleport to where a player was last online          | `huskhomes.command.tpoffline` |
 | `/tpall`                                                        |                              | Teleport everyone to your position                  | `huskhomes.command.tpall`     |
@@ -33,10 +36,16 @@ This is a table of HuskHomes' commands and their required permission nodes. Addi
 | `/back`                                                         |                              | Return to your previous position, or where you died | `huskhomes.command.back`      |
 | `/huskhomes [about/help/reload/update]`                         |                              | View plugin information & reload configs            | `huskhomes.command.huskhomes` |
 
-&dagger;Required permission for basic command execution; some commands require additional permissions for certain functions (See below&hellip;)
+&dagger;Required permission for basic command execution; some commands require additional permissions for certain
+functions (See below&hellip;)
 
 ## Disabling Commands
-If you'd like to disable a command, add it to the `disabled_commands` section of your config file as detailed below. Note that on servers running Paper for versions earlier than Minecraft 1.19.4, or servers just running plain Spigot instead of Paper (not recommended&mdash;please upgrade to Paper!), disabled commands will still be _registered_ but a disabled command message will appear. On servers running Paper for Minecraft 1.19.4+, HuskHomes will be registered as a Paper Plugin (and will appear as such in the `/plugins` menu) and disabled commands will not be registered at all.
+
+If you'd like to disable a command, add it to the `disabled_commands` section of your config file as detailed below.
+Note that on servers running Paper for versions earlier than Minecraft 1.19.4, or servers just running plain Spigot
+instead of Paper (not recommended&mdash;please upgrade to Paper!), disabled commands will still be _registered_ but a
+disabled command message will appear. On servers running Paper for Minecraft 1.19.4+, HuskHomes will be registered as a
+Paper Plugin (and will appear as such in the `/plugins` menu) and disabled commands will not be registered at all.
 
 <details>
 <summary>Disabling a command in config.yml</summary>
@@ -45,64 +54,88 @@ If you'd like to disable a command, add it to the `disabled_commands` section of
 # Disabled commands (e.g. ['/home', '/warp'] to disable /home and /warp)
 disabled_commands: [ '/rtp' ]
 ```
+
 </details>
 
 ## Other Permissions
+
 ### Changing set home, public home & free home limits
-You can modify the maximum number of homes, the allotment of free homes and the number of public homes a user can set through permission nodes.
+
+You can modify the maximum number of homes, the allotment of free homes and the number of public homes a user can set
+through permission nodes.
+
 * `huskhomes.max_homes.<amount>` — Determines the max number of homes a user can set
-* `huskhomes.free_homes.<amount>` — Determines the allotment of homes the user can set for free, before they have to pay&dagger;
+* `huskhomes.free_homes.<amount>` — Determines the allotment of homes the user can set for free, before they have to
+  pay&dagger;
 * `huskhomes.max_public_homes.<amount>` — Determines the maximum number of homes a user can make public
 
 &dagger;Only effective on servers that make use of the economy hook.
 
-If users have multiple permission nodes (i.e. from being in multiple permission groups), HuskHomes will accept the highest. If you would prefer the nodes to _stack_, you can set the `stack_permission_limits` setting in the plugin config file to `true` (under `general`).
+If users have multiple permission nodes (i.e. from being in multiple permission groups), HuskHomes will accept the
+highest. If you would prefer the nodes to _stack_, you can set the `stack_permission_limits` setting in the plugin
+config file to `true` (under `general`).
 
-Note that these permission-set values override the values set in the plugin config (`max_homes`, `max_public_homes` under `general` and `free_homes` under `economy`).
+Note that these permission-set values override the values set in the plugin config (`max_homes`, `max_public_homes`
+under `general` and `free_homes` under `economy`).
 
 ### Return by death on /back
-This permission controls whether users can return to where they died. Note that return by death must be enabled in the config for this to work.
-| Permission                     | Command | Description                           |
+
+This permission controls whether users can return to where they died. Note that return by death must be enabled in the
+config for this to work.
+| Permission | Command | Description |
 |--------------------------------|---------|---------------------------------------|
 | `huskhomes.command.back.death` | `/back` | Use /back to return to where you died |
 
 ### Home privacy
-These permissions allow you to make a home public/private (toggling its privacy). There are also permissions that let you use, edit and delete homes that have not been set publicly.
-| Permission                           | Command                                                                             | Description                                  |
+
+These permissions allow you to make a home public/private (toggling its privacy). There are also permissions that let
+you use, edit and delete homes that have not been set publicly.
+| Permission | Command | Description |
 |--------------------------------------|-------------------------------------------------------------------------------------|----------------------------------------------|
-| `huskhomes.command.edithome.privacy` | `/edithome <name> privacy [public/private]`                                         | Modify the privacy of a home                 |
-| `huskhomes.command.home.other`       | `/homelist <player> [page]`                                                         | View a list of a user's homes                |
-| `huskhomes.command.home.other`       | `/home [<owner_name>.<home_name>]`                                                  | Teleport to a user's home, public or private |
-| `huskhomes.command.edithome.other`   | `/edithome [<owner_name>.<home_name>] [rename/description/relocate/privacy] [args]` | Edit a user's home                           |
-| `huskhomes.command.delhome.other`    | `/delhome [<owner_name>.<home_name>]`                                               | Delete a user's home                         |
+| `huskhomes.command.edithome.privacy` | `/edithome <name> privacy [public/private]`                                         |
+Modify the privacy of a home |
+| `huskhomes.command.home.other`       | `/homelist <player> [page]`                                                         |
+View a list of a user's homes |
+| `huskhomes.command.home.other`       | `/home [<owner_name>.<home_name>]`                                                  |
+Teleport to a user's home, public or private |
+| `huskhomes.command.edithome.other`   | `/edithome [<owner_name>.<home_name>] [rename/description/relocate/privacy] [args]` |
+Edit a user's home |
+| `huskhomes.command.delhome.other`    | `/delhome [<owner_name>.<home_name>]`                                               |
+Delete a user's home |
 
 ### Cooldown, warmup and economy bypasses
+
 These permissions let you bypass teleportation warmup checks, rtp cooldown checks and economy checks
-| Permission                         | Description                                |
+| Permission | Description |
 |------------------------------------|--------------------------------------------|
 | `huskhomes.bypass_teleport_warmup` | Bypass timed teleportation warmups&dagger; |
-| `huskhomes.bypass_economy_checks`  | Bypass economy checks                      |
-| `huskhomes.rtp.bypass_cooldown`    | Bypass the cooldown on /rtp&ddagger;       |
+| `huskhomes.bypass_economy_checks`  | Bypass economy checks |
+| `huskhomes.rtp.bypass_cooldown`    | Bypass the cooldown on /rtp&ddagger; |
 
-&dagger;This is not effective when the teleport warmup time is set `<= 0` in the config file. 
+&dagger;This is not effective when the teleport warmup time is set `<= 0` in the config file.
 
 &ddagger;This is not effective when the /rtp cooldown time is set `<= 0` in the config file.
 
 ### Advanced teleportation
+
 These permissions allow you to use /tp and /rtp to teleport other players remotely and to coordinates.
-| Permission                         | Command                                     | Description                         |
+| Permission | Command | Description |
 |------------------------------------|---------------------------------------------|-------------------------------------|
-| `huskhomes.command.tp.other`       | `/tp [player] <x> <y> <z> [world] [server]` | Teleport a user other than yourself |
-| `huskhomes.command.tp.coordinates` | `/tp [player] <x> <y> <z> [world] [server]` | Teleport to a set of coordinates.   |
-| `huskhomes.command.rtp.other`      | `/rtp [player]`                             | Randomly teleport another player.   |
-| `huskhomes.command.spawn.other`    | `/spawn [player]`                           | Teleport another player to spawn.   |
-| `huskhomes.command.warp.other`     | `/warp [name] [player]`                     | Teleport another player to a warp.  |
+| `huskhomes.command.tp.other`       | `/tp [player] [target] ` | Teleport another player |
+| `huskhomes.command.tp.coordinates` | `/tp [player] <x> <y> <z> [world] [server]` | Teleport to a set of coordinates. |
+| `huskhomes.command.rtp.other`      | `/rtp [player] [world]`                     | Randomly teleport another player. |
+| `huskhomes.command.rtp.world`      | `/rtp [player] [world]`                     | Randomly teleport in a specific
+world. |
+| `huskhomes.command.spawn.other`    | `/spawn [player]`                           | Teleport another player to spawn. |
+| `huskhomes.command.warp.other`     | `/warp [name] [player]`                     | Teleport another player to a
+warp. |
 
 ### /huskhomes command arguments
+
 These permissions control what arguments of the /huskhomes command a user may use.
-| Permission                           | Command                  | Description                                |
+| Permission | Command | Description |
 |--------------------------------------|--------------------------|--------------------------------------------|
-| `huskhomes.command.huskhomes.help`   | `/huskhomes help [page]` | View a list of HuskHomes commands          |
-| `huskhomes.command.huskhomes.about`  | `/huskhomes [about]`     | View the plugin about menu                 |
+| `huskhomes.command.huskhomes.help`   | `/huskhomes help [page]` | View a list of HuskHomes commands |
+| `huskhomes.command.huskhomes.about`  | `/huskhomes [about]`     | View the plugin about menu |
 | `huskhomes.command.huskhomes.reload` | `/huskhomes reload`      | Reload the plugin config and message files |
-| `huskhomes.command.huskhomes.update` | `/huskhomes update`      | Check for updates                          |
+| `huskhomes.command.huskhomes.update` | `/huskhomes update`      | Check for updates |


### PR DESCRIPTION
* Added the ability to random teleport to another world: (`/rtp [player] [world]`)
* Fixed an issue where the RTP generator would only generate positions in the world where the server spawn was set, if there was one set
* Added TAB completion to the `/rtp` command