### PR TITLE
Fix the teleport button not showing up in HomeEditor.

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/command/EditHomeCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/EditHomeCommand.java
@@ -55,7 +55,7 @@ public class EditHomeCommand extends SavedPositionCommand<Home> {
         final Optional<String> operation = parseStringArg(args, 0);
         if (operation.isEmpty()) {
             getHomeEditorWindow(home, !ownerEditing,
-                    !ownerEditing || executor.hasPermission(getOtherPermission()),
+                    ownerEditing || executor.hasPermission(getOtherPermission()),
                     executor.hasPermission(getPermission("privacy")))
                     .forEach(executor::sendMessage);
             return;


### PR DESCRIPTION
bug
![image](https://github.com/morinoparty/MinecraftServer/assets/53502121/03007f37-938b-4cd7-9c03-8c4dcc850320)

fixed
![image](https://github.com/morinoparty/MinecraftServer/assets/53502121/ec3dd827-5888-4b0a-889e-2f80aa41a85a)