### PR TITLE
fix: immutably snapshot online players to mitigate Folia concurrency issues

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
+++ b/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
@@ -70,7 +70,7 @@ public abstract class EventListener {
                 // Synchronize the global player list
                 plugin.runSyncDelayed(() -> this.updateUserList(
                                 onlineUser,
-                                plugin.getOnlineUsers().stream().map(u -> (User) u).toList()),
+                                List.copyOf(plugin.getOnlineUsers()).stream().map(u -> (User) u).toList()),
                         onlineUser,
                         40L
                 );
@@ -117,7 +117,7 @@ public abstract class EventListener {
 
             // Update global lists
             if (plugin.getSettings().getCrossServer().isEnabled()) {
-                final List<User> users = plugin.getOnlineUsers().stream().map(u -> (User) u).toList();
+                final List<User> users = List.copyOf(plugin.getOnlineUsers()).stream().map(u -> (User) u).toList();
                 if (plugin.getSettings().getCrossServer().getBrokerType() == Broker.Type.REDIS) {
                     this.updateUserList(online, users);
                     return;

--- a/common/src/main/java/net/william278/huskhomes/network/MessageHandler.java
+++ b/common/src/main/java/net/william278/huskhomes/network/MessageHandler.java
@@ -31,6 +31,7 @@ import net.william278.huskhomes.util.TransactionResolver;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -45,7 +46,7 @@ public interface MessageHandler {
 
         Message.builder()
                 .type(Message.MessageType.UPDATE_USER_LIST)
-                .payload(Payload.userList(getPlugin().getOnlineUsers().stream().map(online -> (User) online).toList()))
+                .payload(Payload.userList(List.copyOf(getPlugin().getOnlineUsers()).stream().map(online -> (User) online).toList()))
                 .target(message.getSourceServer(), Message.TargetType.SERVER).build()
                 .send(getBroker(), receiver);
     }

--- a/common/src/main/java/net/william278/huskhomes/random/NormalDistributionEngine.java
+++ b/common/src/main/java/net/william278/huskhomes/random/NormalDistributionEngine.java
@@ -131,17 +131,20 @@ public final class NormalDistributionEngine extends RandomTeleportEngine {
 
     @Override
     public CompletableFuture<Optional<Position>> getRandomPosition(@NotNull World world, @NotNull String[] args) {
-        CompletableFuture<Optional<Position>> future = generateSafeLocation(world)
-                .thenApply(loc -> loc.map(resolved -> Position.at(resolved, plugin.getServerName())));
-        for (int i = 1; i <= maxAttempts; i++) {
-            future = future.thenCompose(result -> {
-                if (result.isPresent()) {
-                    return CompletableFuture.completedFuture(result);
-                }
-                return generateSafeLocation(world)
-                        .thenApply(loc -> loc.map(resolved -> Position.at(resolved, plugin.getServerName())));
-            });
+        return attemptRandomPosition(world, 0);
+    }
+
+    private CompletableFuture<Optional<Position>> attemptRandomPosition(@NotNull World world, int attempt) {
+        if (attempt > maxAttempts) {
+            return CompletableFuture.completedFuture(Optional.empty());
         }
-        return future;
+        return generateSafeLocation(world).thenCompose(location -> {
+            if (location.isPresent()) {
+                return CompletableFuture.completedFuture(
+                        location.map(resolved -> Position.at(resolved, plugin.getServerName()))
+                );
+            }
+            return attemptRandomPosition(world, attempt + 1);
+        });
     }
 }

--- a/common/src/main/java/net/william278/huskhomes/random/NormalDistributionEngine.java
+++ b/common/src/main/java/net/william278/huskhomes/random/NormalDistributionEngine.java
@@ -131,17 +131,17 @@ public final class NormalDistributionEngine extends RandomTeleportEngine {
 
     @Override
     public CompletableFuture<Optional<Position>> getRandomPosition(@NotNull World world, @NotNull String[] args) {
-        return plugin.supplyAsync(() -> {
-            Optional<Location> location = generateSafeLocation(world).join();
-            int attempts = 0;
-            while (location.isEmpty()) {
-                location = generateSafeLocation(world).join();
-                if (attempts >= maxAttempts) {
-                    return Optional.empty();
+        CompletableFuture<Optional<Position>> future = generateSafeLocation(world)
+                .thenApply(loc -> loc.map(resolved -> Position.at(resolved, plugin.getServerName())));
+        for (int i = 1; i <= maxAttempts; i++) {
+            future = future.thenCompose(result -> {
+                if (result.isPresent()) {
+                    return CompletableFuture.completedFuture(result);
                 }
-                attempts++;
-            }
-            return location.map(resolved -> Position.at(resolved, plugin.getServerName()));
-        });
+                return generateSafeLocation(world)
+                        .thenApply(loc -> loc.map(resolved -> Position.at(resolved, plugin.getServerName())));
+            });
+        }
+        return future;
     }
 }

--- a/common/src/main/java/net/william278/huskhomes/user/UserProvider.java
+++ b/common/src/main/java/net/william278/huskhomes/user/UserProvider.java
@@ -56,14 +56,14 @@ public interface UserProvider {
     default List<User> getUserList() {
         return Stream.concat(
                 getGlobalUserList().values().stream().flatMap(Collection::stream),
-                getOnlineUsers().stream().filter(o -> !o.isVanished())
+                List.copyOf(getOnlineUsers()).stream().filter(o -> !o.isVanished())
         ).distinct().sorted().toList();
     }
 
     default void setUserList(@NotNull String server, @NotNull List<User> players) {
         getGlobalUserList().values().forEach(list -> {
             list.removeAll(players);
-            list.removeAll(getOnlineUsers());
+            list.removeAll(List.copyOf(getOnlineUsers()));
         });
         getGlobalUserList().put(server, players);
     }


### PR DESCRIPTION
This PR also includes a non-blocking approach for getRandomPosition, which I noticed while reviewing a Canvas (a Folia fork) profiler with over 1,100 concurrent players.