### PR TITLE
Block use of ALL target in teleport commands

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/command/TpCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/TpCommand.java
@@ -21,6 +21,7 @@ package net.william278.huskhomes.command;
 
 import com.google.common.collect.Lists;
 import net.william278.huskhomes.HuskHomes;
+import net.william278.huskhomes.network.Message;
 import net.william278.huskhomes.position.Position;
 import net.william278.huskhomes.teleport.*;
 import net.william278.huskhomes.user.CommandUser;
@@ -88,6 +89,13 @@ public class TpCommand extends Command implements TabCompletable {
     // Execute a teleport
     private void execute(@NotNull CommandUser executor, @NotNull Teleportable teleporter, @NotNull Target target,
                          @NotNull String[] args) {
+        if (teleporter.getName().equals(Message.TARGET_ALL) ||
+                (target instanceof Username username && username.getName().equals(Message.TARGET_ALL))) {
+            plugin.getLocales().getLocale("error_invalid_syntax", getUsage())
+                    .ifPresent(executor::sendMessage);
+            return;
+        }
+
         // Build and execute the teleport
         final TeleportBuilder builder = Teleport.builder(plugin)
                 .teleporter(teleporter)

--- a/common/src/main/java/net/william278/huskhomes/command/TpHereCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/TpHereCommand.java
@@ -20,6 +20,7 @@
 package net.william278.huskhomes.command;
 
 import net.william278.huskhomes.HuskHomes;
+import net.william278.huskhomes.network.Message;
 import net.william278.huskhomes.teleport.Teleport;
 import net.william278.huskhomes.user.OnlineUser;
 import org.jetbrains.annotations.NotNull;
@@ -41,7 +42,7 @@ public class TpHereCommand extends InGameCommand implements UserListTabCompletab
     @Override
     public void execute(@NotNull OnlineUser executor, @NotNull String[] args) {
         final Optional<String> optionalTarget = parseStringArg(args, 0);
-        if (optionalTarget.isEmpty()) {
+        if (optionalTarget.isEmpty() || optionalTarget.get().equals(Message.TARGET_ALL)) {
             plugin.getLocales().getLocale("error_invalid_syntax", getUsage())
                     .ifPresent(executor::sendMessage);
             return;

--- a/common/src/main/java/net/william278/huskhomes/command/TpRequestCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/TpRequestCommand.java
@@ -21,6 +21,7 @@ package net.william278.huskhomes.command;
 
 import net.william278.huskhomes.HuskHomes;
 import net.william278.huskhomes.manager.RequestsManager;
+import net.william278.huskhomes.network.Message;
 import net.william278.huskhomes.teleport.TeleportRequest;
 import net.william278.huskhomes.user.OnlineUser;
 import net.william278.huskhomes.util.TransactionResolver;
@@ -52,7 +53,7 @@ public class TpRequestCommand extends InGameCommand implements UserListTabComple
         }
 
         final Optional<String> optionalTarget = parseStringArg(args, 0);
-        if (optionalTarget.isEmpty()) {
+        if (optionalTarget.isEmpty() || optionalTarget.get().equals(Message.TARGET_ALL)) {
             plugin.getLocales().getLocale("error_invalid_syntax", getUsage())
                     .ifPresent(onlineUser::sendMessage);
             return;


### PR DESCRIPTION
Block the use of `Message.TARGET_ALL` (used in brokers) from being used in teleport command args. Closes #900, which let players teleport (or send teleport requests) to all players on other servers without having the permission node required to use the intended commands.