### PR TITLE
Fix Folia respawn position and /back command issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,19 @@ ext {
     set 'sqlite_driver_version', sqlite_driver_version.toString()
     set 'mysql_driver_version', mysql_driver_version.toString()
     set 'mariadb_driver_version', mariadb_driver_version.toString()
+    set 'h2_driver_version', h2_driver_version.toString()
     set 'postgresql_driver_version', postgresql_driver_version.toString()
+
+    set 'resource_tokens', [
+            version                 : version.toString(),
+            description             : description.toString(),
+            jedis_version           : jedis_version.toString(),
+            sqlite_driver_version   : sqlite_driver_version.toString(),
+            mysql_driver_version    : mysql_driver_version.toString(),
+            mariadb_driver_version  : mariadb_driver_version.toString(),
+            h2_driver_version       : h2_driver_version.toString(),
+            postgresql_driver_version: postgresql_driver_version.toString()
+    ]
 }
 
 publishing {
@@ -111,7 +123,7 @@ allprojects {
     processResources {
         filesMatching(['**/*.json', '**/*.yml']) {
             filter ReplaceTokens as Class, beginToken: '${', endToken: '}',
-                    tokens: rootProject.ext.properties
+                    tokens: rootProject.ext.resource_tokens
         }
     }
 }

--- a/bukkit/src/main/java/net/william278/huskhomes/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/listener/BukkitEventListener.java
@@ -19,8 +19,10 @@
 
 package net.william278.huskhomes.listener;
 
+import io.papermc.lib.PaperLib;
 import net.william278.huskhomes.BukkitHuskHomes;
 import net.william278.huskhomes.config.Settings;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.block.data.type.RespawnAnchor;
@@ -33,9 +35,14 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.*;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class BukkitEventListener extends EventListener implements Listener {
 
     protected boolean usePaperEvents = false;
+    protected final Set<UUID> pendingRespawnTeleport = ConcurrentHashMap.newKeySet();
 
     public BukkitEventListener(@NotNull BukkitHuskHomes plugin) {
         super(plugin);
@@ -48,26 +55,33 @@ public class BukkitEventListener extends EventListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerJoin(PlayerJoinEvent event) {
+        pendingRespawnTeleport.remove(event.getPlayer().getUniqueId());
         getPlugin().getOnlineUserMap().remove(event.getPlayer().getUniqueId());
         super.handlePlayerJoin(getPlugin().getOnlineUser(event.getPlayer()));
     }
 
     @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerLeave(PlayerQuitEvent event) {
+        pendingRespawnTeleport.remove(event.getPlayer().getUniqueId());
         super.handlePlayerLeave(getPlugin().getOnlineUser(event.getPlayer()));
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPlayerDeath(PlayerDeathEvent event) {
-        super.handlePlayerDeath(getPlugin().getOnlineUser(event.getEntity()));
+        final Player player = event.getEntity();
+        pendingRespawnTeleport.add(player.getUniqueId());
+        startRespawnPolling(player);
+        super.handlePlayerDeath(getPlugin().getOnlineUser(player));
     }
 
-    @EventHandler(priority = EventPriority.NORMAL)
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerRespawn(PlayerRespawnEvent event) {
+        pendingRespawnTeleport.remove(event.getPlayer().getUniqueId());
         if (usePaperEvents) {
             return;
         }
         getPlugin().getOnlineUserMap().remove(event.getPlayer().getUniqueId());
+        this.handleLocalServerRespawn(event);
         super.handlePlayerRespawn(getPlugin().getOnlineUser(event.getPlayer()));
     }
 
@@ -123,6 +137,88 @@ public class BukkitEventListener extends EventListener implements Listener {
                 getPlugin().getOnlineUser(event.getPlayer()),
                 BukkitHuskHomes.Adapter.adapt(location, getPlugin().getServerName())
         );
+    }
+
+    /**
+     * Polls every tick after death. Once the player is no longer dead, teleport to spawn immediately.
+     */
+    private void startRespawnPolling(@NotNull Player player) {
+        final UUID uuid = player.getUniqueId();
+        java.util.concurrent.CompletableFuture.runAsync(() -> {
+            final int maxAttempts = 200; // 10 seconds timeout
+            for (int i = 0; i < maxAttempts; i++) {
+                if (!pendingRespawnTeleport.contains(uuid)) {
+                    return;
+                }
+                final Player onlinePlayer = Bukkit.getPlayer(uuid);
+                if (onlinePlayer == null) {
+                    pendingRespawnTeleport.remove(uuid);
+                    return;
+                }
+                if (!onlinePlayer.isDead()) {
+                    pendingRespawnTeleport.remove(uuid);
+                    teleportToSpawnIfNeeded(onlinePlayer);
+                    return;
+                }
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+            pendingRespawnTeleport.remove(uuid);
+        });
+    }
+
+    private void teleportToSpawnIfNeeded(@NotNull Player player) {
+        final Settings.CrossServerSettings crossServer = getPlugin().getSettings().getCrossServer();
+        if (crossServer.isEnabled() && crossServer.isGlobalRespawning()) {
+            return;
+        }
+
+        final boolean alwaysAtSpawn = getPlugin().getSettings().getGeneral().isAlwaysRespawnAtSpawn();
+        if (!alwaysAtSpawn && player.getBedSpawnLocation() != null) {
+            return;
+        }
+
+        final var spawnOpt = getPlugin().getSpawn();
+        if (spawnOpt.isEmpty()) {
+            return;
+        }
+
+        final var spawn = spawnOpt.get();
+        final Location loc = BukkitHuskHomes.Adapter.adapt(spawn);
+        if (loc == null || loc.getWorld() == null) {
+            return;
+        }
+
+        player.setFallDistance(0f);
+        PaperLib.teleportAsync(player, loc, PlayerTeleportEvent.TeleportCause.PLUGIN);
+    }
+
+    protected final void handleLocalServerRespawn(@NotNull PlayerRespawnEvent event) {
+        final Settings.CrossServerSettings crossServer = getPlugin().getSettings().getCrossServer();
+        if (crossServer.isEnabled() && crossServer.isGlobalRespawning()) {
+            return;
+        }
+
+        if (!getPlugin().getSettings().getGeneral().isAlwaysRespawnAtSpawn()
+                && (event.isBedSpawn() || event.isAnchorSpawn())) {
+            return;
+        }
+
+        final var spawnOpt = getPlugin().getSpawn();
+        if (spawnOpt.isEmpty()) {
+            return;
+        }
+
+        final Location loc = BukkitHuskHomes.Adapter.adapt(spawnOpt.get());
+        if (loc == null || loc.getWorld() == null) {
+            return;
+        }
+
+        event.setRespawnLocation(loc);
     }
 
     @Override

--- a/common/src/main/java/net/william278/huskhomes/teleport/Teleport.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/Teleport.java
@@ -33,6 +33,7 @@ import net.william278.huskhomes.position.Position;
 import net.william278.huskhomes.user.OnlineUser;
 import net.william278.huskhomes.util.TransactionResolver;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -54,6 +55,8 @@ public class Teleport implements Completable {
     protected final List<TransactionResolver.Action> actions;
     private final boolean async;
     protected final boolean updateLastPosition;
+    @Nullable
+    protected final Position sourcePosition;
 
     protected Teleport(@NotNull OnlineUser executor, @NotNull Teleportable teleporter, @NotNull Target target,
                        @NotNull Type type, boolean updateLastPosition,
@@ -69,6 +72,7 @@ public class Teleport implements Completable {
                 .map(command -> executor.hasPermission(command.getPermission())
                         && executor.hasPermission(command.getPermission("previous")))
                 .orElse(false);
+        this.sourcePosition = (teleporter instanceof OnlineUser online) ? online.getPosition() : null;
     }
 
     @NotNull
@@ -97,8 +101,9 @@ public class Teleport implements Completable {
             if (localTarget.isPresent()) {
                 fireEvent((event) -> {
                     performTransactions();
-                    if (updateLastPosition && canReturnToWorld(teleporter)) {
-                        plugin.getDatabase().setLastPosition(teleporter, teleporter.getPosition());
+                    if (updateLastPosition && sourcePosition != null
+                            && canReturnToWorld(sourcePosition)) {
+                        plugin.getDatabase().setLastPosition(teleporter, sourcePosition);
                     }
                     teleporter.teleportLocally(localTarget.get().getPosition(), async);
                     this.displayTeleportingComplete(teleporter);
@@ -123,8 +128,9 @@ public class Teleport implements Completable {
 
         fireEvent((event) -> {
             performTransactions();
-            if (updateLastPosition && canReturnToWorld(teleporter)) {
-                plugin.getDatabase().setLastPosition(teleporter, teleporter.getPosition());
+            if (updateLastPosition && sourcePosition != null
+                    && canReturnToWorld(sourcePosition)) {
+                plugin.getDatabase().setLastPosition(teleporter, sourcePosition);
             }
 
             final Position target = (Position) this.target;
@@ -166,8 +172,8 @@ public class Teleport implements Completable {
         }));
     }
 
-    private boolean canReturnToWorld(@NotNull OnlineUser user) {
-        return plugin.getSettings().getGeneral().getBackCommand().canReturnToWorld(user.getPosition().getWorld());
+    private boolean canReturnToWorld(@NotNull Position position) {
+        return plugin.getSettings().getGeneral().getBackCommand().canReturnToWorld(position.getWorld());
     }
 
     @NotNull

--- a/paper/src/main/java/net/william278/huskhomes/listener/PaperEventListener.java
+++ b/paper/src/main/java/net/william278/huskhomes/listener/PaperEventListener.java
@@ -62,10 +62,12 @@ public class PaperEventListener extends BukkitEventListener implements Listener 
         );
     }
 
-    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST)
     @Override
     public void onPlayerRespawn(PlayerRespawnEvent event) {
+        pendingRespawnTeleport.remove(event.getPlayer().getUniqueId());
         getPlugin().getOnlineUserMap().remove(event.getPlayer().getUniqueId());
+        this.handleLocalServerRespawn(event);
         if (event.getRespawnReason() != PlayerRespawnEvent.RespawnReason.DEATH) {
             return;
         }


### PR DESCRIPTION
## Summary

This PR fixes two critical issues when running HuskHomes on Folia:

### 1. Players respawn at incorrect locations after death
**Root cause:** `PlayerRespawnEvent` is never fired on Folia, so the respawn handler in `PaperEventListener.onPlayerRespawn()` never executes.

**Fix:** Added an async death-respawn polling mechanism in `BukkitEventListener`:
- On `PlayerDeathEvent`, the player's UUID is added to a pending set and a polling task is started
- The task checks `Player.isDead()` every ~50ms on an async thread
- Once the player respawns, it immediately teleports them to the HuskHomes spawn via `PaperLib.teleportAsync()`
- If `PlayerRespawnEvent` does fire (non-Folia servers), the pending flag is cleared and polling exits, preventing duplicate teleports

Also removed `ignoreCancelled = true` from `PaperEventListener.onPlayerRespawn()` since `PlayerRespawnEvent` is not `Cancellable`.

### 2. `/back` command teleports to completely wrong locations
**Root cause:** `TimedTeleport` runs its warmup countdown via `AsynchronousScheduler.runAtFixedRate()`. When the warmup completes, `Teleport.executeLocal()` is called on an **async thread**, which then calls `teleporter.getPosition()` → `Player.getLocation()`. On Folia, `Player.getLocation()` must be called on the entity's owning region thread — calling it from an async thread returns incorrect/stale data. This garbage position is then saved as `lastPosition` in the database.

**Fix:** Capture the teleporter's source position at `Teleport` construction time (when still on the correct thread) and store it as `sourcePosition`. `executeLocal()` now uses this pre-captured position for `setLastPosition()` instead of reading from the player at execution time.

### Additional
- Added missing `h2_driver_version` to `build.gradle` `resource_tokens` map to fix build errors

### Files changed
- `bukkit/.../listener/BukkitEventListener.java` — respawn polling mechanism
- `paper/.../listener/PaperEventListener.java` — remove ignoreCancelled
- `common/.../teleport/Teleport.java` — pre-capture sourcePosition
- `build.gradle` — fix resource_tokens

### Testing
Tested on Folia server with death/respawn and /back scenarios. Respawn now goes to the correct spawn coordinates, and /back returns to the correct previous position.