### PR TITLE
Do not interrupt teleport when EntityDamageEvent is cancelled

### DIFF
--- a/bukkit/src/main/java/net/william278/huskhomes/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/listener/BukkitEventListener.java
@@ -90,12 +90,12 @@ public class BukkitEventListener extends EventListener implements Listener {
         );
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = false)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerTakeDamage(EntityDamageEvent event) {
         if (!(event.getEntity() instanceof Player player)) {
             return;
         }
-        // Cancel warmup on any "hurt" event during warmup, even if damage is cancelled/blocked/absorbed
+        // Cancel warmup on any "hurt" event during warmup, even if damage is absorbed
         if (!getPlugin().isWarmingUp(player.getUniqueId()) || event.getDamage() <= 0) {
             return;
         }


### PR DESCRIPTION
Players cannot deal damage inside protected regions such as WorldGuard areas. Continuous attacks from other players will prevent HuskHomes teleportation indefinitely.

No need to abort teleport if EntityDamageEvent is cancelled.

This issue was introduced as a result.
https://github.com/WiIIiam278/HuskHomes/pull/927
