### PR TITLE
fix: add Folia 26.1.2 support via native Paper teleport API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
             1.21.6
             1.21.8
             1.21.11
+            26.1.2
           java: 17
       - name: 'Fabric 1.21.1: Publish to Modrinth & CurseForge 🧵'
         uses: WiIIiam278/mc-publish@hangar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
             1.21.6
             1.21.8
             1.21.11
+            26.1.2
           java: 17
       - name: 'Fabric 1.21.1: Publish to Modrinth & CurseForge 🧵'
         uses: WiIIiam278/mc-publish@hangar

--- a/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
@@ -52,6 +52,8 @@ import net.william278.huskhomes.random.RandomTeleportEngine;
 import net.william278.huskhomes.user.*;
 import net.william278.huskhomes.util.BukkitSavePositionProvider;
 import net.william278.huskhomes.util.BukkitTask;
+import net.william278.huskhomes.util.PaperLibPlatformOperations;
+import net.william278.huskhomes.util.PlatformOperations;
 import net.william278.huskhomes.util.UnsafeBlocks;
 import net.william278.toilet.BukkitToilet;
 import net.william278.toilet.Toilet;
@@ -87,6 +89,8 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes, BukkitTask
     private RegionalScheduler regionalScheduler;
     private MorePaperLib morePaperLib;
     private Toilet toilet;
+    @Nullable
+    private PlatformOperations platformOperations;
 
     private final Set<SavedUser> savedUsers = Sets.newHashSet();
     private final Set<UUID> currentlyOnWarmup = Sets.newConcurrentHashSet();
@@ -298,6 +302,14 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes, BukkitTask
     @NotNull
     public GracefulScheduling getScheduler() {
         return morePaperLib.scheduling();
+    }
+
+    @NotNull
+    public PlatformOperations getPlatformOperations() {
+        if (platformOperations == null) {
+            platformOperations = new PaperLibPlatformOperations(this);
+        }
+        return platformOperations;
     }
 
     @NotNull

--- a/bukkit/src/main/java/net/william278/huskhomes/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/listener/BukkitEventListener.java
@@ -21,6 +21,8 @@ package net.william278.huskhomes.listener;
 
 import net.william278.huskhomes.BukkitHuskHomes;
 import net.william278.huskhomes.config.Settings;
+import net.william278.huskhomes.user.OnlineUser;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.block.data.type.RespawnAnchor;
@@ -33,9 +35,16 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.*;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class BukkitEventListener extends EventListener implements Listener {
 
+    private static final int MAX_RESPAWN_POLL_ATTEMPTS = 200;
+
     protected boolean usePaperEvents = false;
+    protected final Set<UUID> pendingRespawnTeleport = ConcurrentHashMap.newKeySet();
 
     public BukkitEventListener(@NotNull BukkitHuskHomes plugin) {
         super(plugin);
@@ -48,26 +57,33 @@ public class BukkitEventListener extends EventListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerJoin(PlayerJoinEvent event) {
+        pendingRespawnTeleport.remove(event.getPlayer().getUniqueId());
         getPlugin().getOnlineUserMap().remove(event.getPlayer().getUniqueId());
         super.handlePlayerJoin(getPlugin().getOnlineUser(event.getPlayer()));
     }
 
     @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerLeave(PlayerQuitEvent event) {
+        pendingRespawnTeleport.remove(event.getPlayer().getUniqueId());
         super.handlePlayerLeave(getPlugin().getOnlineUser(event.getPlayer()));
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPlayerDeath(PlayerDeathEvent event) {
-        super.handlePlayerDeath(getPlugin().getOnlineUser(event.getEntity()));
+        final Player player = event.getEntity();
+        pendingRespawnTeleport.add(player.getUniqueId());
+        startRespawnPolling(player);
+        super.handlePlayerDeath(getPlugin().getOnlineUser(player));
     }
 
-    @EventHandler(priority = EventPriority.NORMAL)
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerRespawn(PlayerRespawnEvent event) {
+        pendingRespawnTeleport.remove(event.getPlayer().getUniqueId());
         if (usePaperEvents) {
             return;
         }
         getPlugin().getOnlineUserMap().remove(event.getPlayer().getUniqueId());
+        handleLocalServerRespawn(event);
         super.handlePlayerRespawn(getPlugin().getOnlineUser(event.getPlayer()));
     }
 
@@ -125,11 +141,86 @@ public class BukkitEventListener extends EventListener implements Listener {
         );
     }
 
+    /**
+     * Poll on the entity scheduler until the player has respawned, then teleport to spawn if needed.
+     */
+    private void startRespawnPolling(@NotNull Player player) {
+        pollRespawn(player.getUniqueId(), 0, getPlugin().getOnlineUser(player));
+    }
+
+    private void pollRespawn(@NotNull UUID uuid, int attempt, @NotNull OnlineUser user) {
+        if (!pendingRespawnTeleport.contains(uuid)) {
+            return;
+        }
+        if (attempt >= MAX_RESPAWN_POLL_ATTEMPTS) {
+            pendingRespawnTeleport.remove(uuid);
+            return;
+        }
+
+        getPlugin().runSyncDelayed(() -> {
+            if (!pendingRespawnTeleport.contains(uuid)) {
+                return;
+            }
+            final Player onlinePlayer = Bukkit.getPlayer(uuid);
+            if (onlinePlayer == null || !onlinePlayer.isOnline()) {
+                pendingRespawnTeleport.remove(uuid);
+                return;
+            }
+            if (!onlinePlayer.isDead()) {
+                pendingRespawnTeleport.remove(uuid);
+                teleportToSpawnIfNeeded(onlinePlayer);
+                return;
+            }
+            pollRespawn(uuid, attempt + 1, getPlugin().getOnlineUser(onlinePlayer));
+        }, user, 1L);
+    }
+
+    private void teleportToSpawnIfNeeded(@NotNull Player player) {
+        final Settings.CrossServerSettings crossServer = getPlugin().getSettings().getCrossServer();
+        if (crossServer.isEnabled() && crossServer.isGlobalRespawning()) {
+            return;
+        }
+
+        if (!getPlugin().getSettings().getGeneral().isAlwaysRespawnAtSpawn()
+                && player.getBedSpawnLocation() != null) {
+            return;
+        }
+
+        getPlugin().getSpawn().ifPresent(spawn -> {
+            final Location location = BukkitHuskHomes.Adapter.adapt(spawn);
+            if (location.getWorld() == null) {
+                return;
+            }
+            player.setFallDistance(0f);
+            getPlugin().getPlatformOperations().teleport(
+                    player, location, PlayerTeleportEvent.TeleportCause.PLUGIN, true
+            );
+        });
+    }
+
+    protected final void handleLocalServerRespawn(@NotNull PlayerRespawnEvent event) {
+        final Settings.CrossServerSettings crossServer = getPlugin().getSettings().getCrossServer();
+        if (crossServer.isEnabled() && crossServer.isGlobalRespawning()) {
+            return;
+        }
+
+        if (!getPlugin().getSettings().getGeneral().isAlwaysRespawnAtSpawn()
+                && (event.isBedSpawn() || event.isAnchorSpawn())) {
+            return;
+        }
+
+        getPlugin().getSpawn().ifPresent(spawn -> {
+            final Location location = BukkitHuskHomes.Adapter.adapt(spawn);
+            if (location.getWorld() != null) {
+                event.setRespawnLocation(location);
+            }
+        });
+    }
+
     @Override
     @NotNull
     protected BukkitHuskHomes getPlugin() {
         return (BukkitHuskHomes) super.getPlugin();
     }
-
 
 }

--- a/bukkit/src/main/java/net/william278/huskhomes/user/BukkitUser.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/user/BukkitUser.java
@@ -19,7 +19,6 @@
 
 package net.william278.huskhomes.user;
 
-import io.papermc.lib.PaperLib;
 import net.william278.huskhomes.BukkitHuskHomes;
 import net.william278.huskhomes.network.PluginMessageBroker;
 import net.william278.huskhomes.position.Location;
@@ -123,15 +122,15 @@ public class BukkitUser extends OnlineUser {
         }
 
         // Run on the appropriate thread scheduler for this platform
+        final BukkitHuskHomes bukkitPlugin = (BukkitHuskHomes) plugin;
         plugin.runSync(() -> {
             bukkitPlayer.leaveVehicle();
             bukkitPlayer.eject();
             bukkitPlayer.setFallDistance(0f);
-            if (async || ((BukkitHuskHomes) plugin).getScheduler().isUsingFolia()) {
-                PaperLib.teleportAsync(bukkitPlayer, location, PlayerTeleportEvent.TeleportCause.PLUGIN);
-                return;
-            }
-            bukkitPlayer.teleport(location, PlayerTeleportEvent.TeleportCause.PLUGIN);
+            final boolean preferAsync = async || !bukkitPlugin.getPlatformOperations().supportsSyncTeleport();
+            bukkitPlugin.getPlatformOperations().teleport(
+                    bukkitPlayer, location, PlayerTeleportEvent.TeleportCause.PLUGIN, preferAsync
+            );
         }, this);
     }
 

--- a/bukkit/src/main/java/net/william278/huskhomes/util/BukkitSavePositionProvider.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/util/BukkitSavePositionProvider.java
@@ -19,7 +19,6 @@
 
 package net.william278.huskhomes.util;
 
-import io.papermc.lib.PaperLib;
 import net.william278.huskhomes.BukkitHuskHomes;
 import net.william278.huskhomes.position.Location;
 import org.bukkit.Chunk;
@@ -46,7 +45,7 @@ public interface BukkitSavePositionProvider extends SavePositionProvider {
         }
 
         // Search nearby blocks for a safe location
-        return PaperLib.getChunkAtAsync(bukkitLocation)
+        return ((BukkitHuskHomes) getPlugin()).getPlatformOperations().getChunkAtAsync(bukkitLocation)
                 .thenApply(Chunk::getChunkSnapshot)
                 .thenApply(snapshot -> findSafeLocationNear(
                         location,

--- a/bukkit/src/main/java/net/william278/huskhomes/util/PaperLibPlatformOperations.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/util/PaperLibPlatformOperations.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.huskhomes.util;
+
+import io.papermc.lib.PaperLib;
+import net.william278.huskhomes.BukkitHuskHomes;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Default platform operations using PaperLib for Spigot and legacy Bukkit compatibility.
+ */
+public class PaperLibPlatformOperations implements PlatformOperations {
+
+    private final BukkitHuskHomes plugin;
+
+    public PaperLibPlatformOperations(@NotNull BukkitHuskHomes plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void teleport(@NotNull Player player, @NotNull Location location,
+                         @NotNull PlayerTeleportEvent.TeleportCause cause, boolean preferAsync) {
+        if (preferAsync || plugin.getScheduler().isUsingFolia()) {
+            PaperLib.teleportAsync(player, location, cause);
+            return;
+        }
+        player.teleport(location, cause);
+    }
+
+    @Override
+    public boolean supportsSyncTeleport() {
+        return true;
+    }
+
+    @Override
+    @NotNull
+    public CompletableFuture<Chunk> getChunkAtAsync(@NotNull Location location) {
+        return PaperLib.getChunkAtAsync(location);
+    }
+
+}

--- a/bukkit/src/main/java/net/william278/huskhomes/util/PlatformOperations.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/util/PlatformOperations.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.huskhomes.util;
+
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Platform-specific Bukkit operations abstracting Paper/Folia native APIs from Spigot fallbacks.
+ */
+public interface PlatformOperations {
+
+    /**
+     * Teleport a player. Native Paper/Folia implementations always use {@code teleportAsync}
+     * regardless of {@code preferAsync}.
+     *
+     * @param player      the player to teleport
+     * @param location    the destination
+     * @param cause       the teleport cause
+     * @param preferAsync whether asynchronous teleportation is preferred
+     */
+    void teleport(@NotNull Player player, @NotNull Location location,
+                  @NotNull PlayerTeleportEvent.TeleportCause cause, boolean preferAsync);
+
+    /**
+     * Whether synchronous {@link Player#teleport(Location)} is safe on this platform.
+     *
+     * @return {@code false} on Folia and other platforms that require async teleports
+     */
+    boolean supportsSyncTeleport();
+
+    /**
+     * Load a chunk asynchronously at the given location.
+     *
+     * @param location the location to load the chunk at
+     * @return a future completing with the loaded chunk
+     */
+    @NotNull
+    CompletableFuture<Chunk> getChunkAtAsync(@NotNull Location location);
+
+}

--- a/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
+++ b/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
@@ -70,7 +70,7 @@ public abstract class EventListener {
                 // Synchronize the global player list
                 plugin.runSyncDelayed(() -> this.updateUserList(
                                 onlineUser,
-                                plugin.getOnlineUsers().stream().map(u -> (User) u).toList()),
+                                List.copyOf(plugin.getOnlineUsers()).stream().map(u -> (User) u).toList()),
                         onlineUser,
                         40L
                 );
@@ -117,7 +117,7 @@ public abstract class EventListener {
 
             // Update global lists
             if (plugin.getSettings().getCrossServer().isEnabled()) {
-                final List<User> users = plugin.getOnlineUsers().stream().map(u -> (User) u).toList();
+                final List<User> users = List.copyOf(plugin.getOnlineUsers()).stream().map(u -> (User) u).toList();
                 if (plugin.getSettings().getCrossServer().getBrokerType() == Broker.Type.REDIS) {
                     this.updateUserList(online, users);
                     return;

--- a/common/src/main/java/net/william278/huskhomes/network/MessageHandler.java
+++ b/common/src/main/java/net/william278/huskhomes/network/MessageHandler.java
@@ -31,6 +31,7 @@ import net.william278.huskhomes.util.TransactionResolver;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -45,7 +46,8 @@ public interface MessageHandler {
 
         Message.builder()
                 .type(Message.MessageType.UPDATE_USER_LIST)
-                .payload(Payload.userList(getPlugin().getOnlineUsers().stream().map(online -> (User) online).toList()))
+                .payload(Payload.userList(List.copyOf(getPlugin().getOnlineUsers()).stream()
+                        .map(online -> (User) online).toList()))
                 .target(message.getSourceServer(), Message.TargetType.SERVER).build()
                 .send(getBroker(), receiver);
     }

--- a/common/src/main/java/net/william278/huskhomes/random/NormalDistributionEngine.java
+++ b/common/src/main/java/net/william278/huskhomes/random/NormalDistributionEngine.java
@@ -131,17 +131,20 @@ public final class NormalDistributionEngine extends RandomTeleportEngine {
 
     @Override
     public CompletableFuture<Optional<Position>> getRandomPosition(@NotNull World world, @NotNull String[] args) {
-        return plugin.supplyAsync(() -> {
-            Optional<Location> location = generateSafeLocation(world).join();
-            int attempts = 0;
-            while (location.isEmpty()) {
-                location = generateSafeLocation(world).join();
-                if (attempts >= maxAttempts) {
-                    return Optional.empty();
-                }
-                attempts++;
+        return attemptRandomPosition(world, 0);
+    }
+
+    private CompletableFuture<Optional<Position>> attemptRandomPosition(@NotNull World world, int attempt) {
+        if (attempt > maxAttempts) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        return generateSafeLocation(world).thenCompose(location -> {
+            if (location.isPresent()) {
+                return CompletableFuture.completedFuture(
+                        location.map(resolved -> Position.at(resolved, plugin.getServerName()))
+                );
             }
-            return location.map(resolved -> Position.at(resolved, plugin.getServerName()));
+            return attemptRandomPosition(world, attempt + 1);
         });
     }
 }

--- a/common/src/main/java/net/william278/huskhomes/teleport/Teleport.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/Teleport.java
@@ -33,6 +33,7 @@ import net.william278.huskhomes.position.Position;
 import net.william278.huskhomes.user.OnlineUser;
 import net.william278.huskhomes.util.TransactionResolver;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -54,6 +55,8 @@ public class Teleport implements Completable {
     protected final List<TransactionResolver.Action> actions;
     private final boolean async;
     protected final boolean updateLastPosition;
+    @Nullable
+    protected final Position sourcePosition;
 
     protected Teleport(@NotNull OnlineUser executor, @NotNull Teleportable teleporter, @NotNull Target target,
                        @NotNull Type type, boolean updateLastPosition,
@@ -69,6 +72,7 @@ public class Teleport implements Completable {
                 .map(command -> executor.hasPermission(command.getPermission())
                         && executor.hasPermission(command.getPermission("previous")))
                 .orElse(false);
+        this.sourcePosition = (teleporter instanceof OnlineUser online) ? online.getPosition() : null;
     }
 
     @NotNull
@@ -97,8 +101,9 @@ public class Teleport implements Completable {
             if (localTarget.isPresent()) {
                 fireEvent((event) -> {
                     performTransactions();
-                    if (updateLastPosition && canReturnToWorld(teleporter)) {
-                        plugin.getDatabase().setLastPosition(teleporter, teleporter.getPosition());
+                    if (updateLastPosition && sourcePosition != null
+                            && canReturnToWorld(sourcePosition)) {
+                        plugin.getDatabase().setLastPosition(teleporter, sourcePosition);
                     }
                     teleporter.teleportLocally(localTarget.get().getPosition(), async);
                     this.displayTeleportingComplete(teleporter);
@@ -123,8 +128,9 @@ public class Teleport implements Completable {
 
         fireEvent((event) -> {
             performTransactions();
-            if (updateLastPosition && canReturnToWorld(teleporter)) {
-                plugin.getDatabase().setLastPosition(teleporter, teleporter.getPosition());
+            if (updateLastPosition && sourcePosition != null
+                    && canReturnToWorld(sourcePosition)) {
+                plugin.getDatabase().setLastPosition(teleporter, sourcePosition);
             }
 
             final Position target = (Position) this.target;
@@ -166,8 +172,8 @@ public class Teleport implements Completable {
         }));
     }
 
-    private boolean canReturnToWorld(@NotNull OnlineUser user) {
-        return plugin.getSettings().getGeneral().getBackCommand().canReturnToWorld(user.getPosition().getWorld());
+    private boolean canReturnToWorld(@NotNull Position position) {
+        return plugin.getSettings().getGeneral().getBackCommand().canReturnToWorld(position.getWorld());
     }
 
     @NotNull

--- a/common/src/main/java/net/william278/huskhomes/user/UserProvider.java
+++ b/common/src/main/java/net/william278/huskhomes/user/UserProvider.java
@@ -56,14 +56,14 @@ public interface UserProvider {
     default List<User> getUserList() {
         return Stream.concat(
                 getGlobalUserList().values().stream().flatMap(Collection::stream),
-                getOnlineUsers().stream().filter(o -> !o.isVanished())
+                List.copyOf(getOnlineUsers()).stream().filter(o -> !o.isVanished())
         ).distinct().sorted().toList();
     }
 
     default void setUserList(@NotNull String server, @NotNull List<User> players) {
         getGlobalUserList().values().forEach(list -> {
             list.removeAll(players);
-            list.removeAll(getOnlineUsers());
+            list.removeAll(List.copyOf(getOnlineUsers()));
         });
         getGlobalUserList().put(server, players);
     }

--- a/paper/src/main/java/net/william278/huskhomes/PaperHuskHomes.java
+++ b/paper/src/main/java/net/william278/huskhomes/PaperHuskHomes.java
@@ -21,12 +21,22 @@ package net.william278.huskhomes;
 
 import net.kyori.adventure.audience.Audience;
 import net.william278.huskhomes.listener.PaperEventListener;
+import net.william278.huskhomes.util.NativePaperPlatformOperations;
+import net.william278.huskhomes.util.PlatformOperations;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
 public class PaperHuskHomes extends BukkitHuskHomes {
+
+    private final PlatformOperations platformOperations = new NativePaperPlatformOperations(this);
+
+    @NotNull
+    @Override
+    public PlatformOperations getPlatformOperations() {
+        return platformOperations;
+    }
 
     @Override
     @NotNull

--- a/paper/src/main/java/net/william278/huskhomes/listener/PaperEventListener.java
+++ b/paper/src/main/java/net/william278/huskhomes/listener/PaperEventListener.java
@@ -62,10 +62,12 @@ public class PaperEventListener extends BukkitEventListener implements Listener 
         );
     }
 
-    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     @Override
     public void onPlayerRespawn(PlayerRespawnEvent event) {
+        pendingRespawnTeleport.remove(event.getPlayer().getUniqueId());
         getPlugin().getOnlineUserMap().remove(event.getPlayer().getUniqueId());
+        handleLocalServerRespawn(event);
         if (event.getRespawnReason() != PlayerRespawnEvent.RespawnReason.DEATH) {
             return;
         }

--- a/paper/src/main/java/net/william278/huskhomes/util/NativePaperPlatformOperations.java
+++ b/paper/src/main/java/net/william278/huskhomes/util/NativePaperPlatformOperations.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.huskhomes.util;
+
+import net.william278.huskhomes.BukkitHuskHomes;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+
+/**
+ * Platform operations using native Paper/Folia APIs.
+ */
+public class NativePaperPlatformOperations implements PlatformOperations {
+
+    private final BukkitHuskHomes plugin;
+
+    public NativePaperPlatformOperations(@NotNull BukkitHuskHomes plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void teleport(@NotNull Player player, @NotNull Location location,
+                         @NotNull PlayerTeleportEvent.TeleportCause cause, boolean preferAsync) {
+        player.teleportAsync(location, cause)
+                .exceptionally(throwable -> {
+                    plugin.log(Level.WARNING,
+                            String.format("Failed to teleport player %s asynchronously", player.getName()),
+                            throwable);
+                    return false;
+                })
+                .thenAccept(success -> {
+                    if (!success) {
+                        plugin.log(Level.WARNING,
+                                String.format("Asynchronous teleport for player %s completed unsuccessfully",
+                                        player.getName()));
+                    }
+                });
+    }
+
+    @Override
+    public boolean supportsSyncTeleport() {
+        return false;
+    }
+
+    @Override
+    @NotNull
+    public CompletableFuture<Chunk> getChunkAtAsync(@NotNull Location location) {
+        final World world = location.getWorld();
+        if (world == null) {
+            return CompletableFuture.failedFuture(new IllegalStateException("Location world is null"));
+        }
+        return world.getChunkAtAsync(location, true);
+    }
+
+}


### PR DESCRIPTION
## Summary

- Add a `PlatformOperations` bridge so Paper/Folia uses native `Player#teleportAsync` and `World#getChunkAtAsync`, avoiding PaperLib 1.0.8 falling back to synchronous teleports on Folia 26.1.2.
- Keep PaperLib as the Spigot fallback path via `PaperLibPlatformOperations`.
- Fix Folia-related stability issues: online player list snapshots, `/back` source position capture, non-blocking RTP retries, and local respawn handling for Folia.

Fixes #980