### PR TITLE
26.1 support

### DIFF
--- a/bukkit/src/main/java/net/william278/huskhomes/user/BukkitUser.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/user/BukkitUser.java
@@ -37,6 +37,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 /**
@@ -128,7 +129,7 @@ public class BukkitUser extends OnlineUser {
             bukkitPlayer.eject();
             bukkitPlayer.setFallDistance(0f);
             if (async || ((BukkitHuskHomes) plugin).getScheduler().isUsingFolia()) {
-                PaperLib.teleportAsync(bukkitPlayer, location, PlayerTeleportEvent.TeleportCause.PLUGIN);
+                teleportUsingPlatformAsync(location);
                 return;
             }
             bukkitPlayer.teleport(location, PlayerTeleportEvent.TeleportCause.PLUGIN);
@@ -186,5 +187,43 @@ public class BukkitUser extends OnlineUser {
     @Override
     public boolean isValid() {
         return getHealth() > 0;
+    }
+
+    /**
+     * Attempts to teleport the player asynchronously using the platform's native async teleport method,
+     * logging a warning if the teleport fails.
+     *
+     * @param location the {@link org.bukkit.Location} to teleport the player to
+     */
+    private void teleportUsingPlatformAsync(@NotNull org.bukkit.Location location) {
+        invokePlatformAsyncTeleport(location).exceptionally(throwable -> {
+            plugin.log(Level.WARNING, String.format("Failed to teleport player %s asynchronously", getName()), throwable);
+            return false;
+        });
+    }
+
+    /**
+     * Invokes the platform's asynchronous teleport method for the player. First attempts to use
+     * the native {@code teleportAsync} method via reflection (available on Paper and Folia), falling
+     * back to {@link PaperLib#teleportAsync} if the method is not found.
+     *
+     * @param location the {@link org.bukkit.Location} to teleport the player to
+     * @return a {@link CompletableFuture} that completes with {@code true} if the teleport succeeded,
+     *         or {@code false} otherwise
+     * @throws IllegalStateException if the reflective invocation fails for a reason other than the
+     *                               method not being present
+     */
+    @NotNull
+    @SuppressWarnings("unchecked")
+    private CompletableFuture<Boolean> invokePlatformAsyncTeleport(@NotNull org.bukkit.Location location) {
+        try {
+            return (CompletableFuture<Boolean>) bukkitPlayer.getClass()
+                    .getMethod("teleportAsync", org.bukkit.Location.class, PlayerTeleportEvent.TeleportCause.class)
+                    .invoke(bukkitPlayer, location, PlayerTeleportEvent.TeleportCause.PLUGIN);
+        } catch (NoSuchMethodException e) {
+            return PaperLib.teleportAsync(bukkitPlayer, location, PlayerTeleportEvent.TeleportCause.PLUGIN);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to invoke asynchronous teleport", e);
+        }
     }
 }

--- a/bukkit/src/main/java/net/william278/huskhomes/util/BukkitSavePositionProvider.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/util/BukkitSavePositionProvider.java
@@ -27,11 +27,24 @@ import org.bukkit.ChunkSnapshot;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public interface BukkitSavePositionProvider extends SavePositionProvider {
+
+    // World#getChunkAtAsync(int, int) exists on Paper/Folia but not in spigot-api; resolve once at startup
+    @Nullable Method CHUNK_AT_ASYNC = resolveChunkAtAsync();
+
+    private static @Nullable Method resolveChunkAtAsync() {
+        try {
+            return World.class.getMethod("getChunkAtAsync", int.class, int.class);
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
+    }
 
     @Override
     default CompletableFuture<Optional<Location>> findSafeGroundLocation(@NotNull Location location) {
@@ -46,7 +59,7 @@ public interface BukkitSavePositionProvider extends SavePositionProvider {
         }
 
         // Search nearby blocks for a safe location
-        return PaperLib.getChunkAtAsync(bukkitLocation)
+        return getChunkAtAsync(bukkitLocation)
                 .thenApply(Chunk::getChunkSnapshot)
                 .thenApply(snapshot -> findSafeLocationNear(
                         location,
@@ -54,6 +67,22 @@ public interface BukkitSavePositionProvider extends SavePositionProvider {
                         getMinHeight(bukkitLocation.getWorld()),
                         getMaxHeight(bukkitLocation.getWorld())
                 ));
+    }
+
+    // On Paper/Folia, use the native async API (Folia-safe). Fall back to PaperLib on Spigot.
+    @SuppressWarnings("unchecked")
+    private static CompletableFuture<Chunk> getChunkAtAsync(org.bukkit.Location location) {
+        if (CHUNK_AT_ASYNC != null) {
+            try {
+                return (CompletableFuture<Chunk>) CHUNK_AT_ASYNC.invoke(
+                        location.getWorld(),
+                        location.getBlockX() >> 4,
+                        location.getBlockZ() >> 4
+                );
+            } catch (ReflectiveOperationException ignored) {
+            }
+        }
+        return PaperLib.getChunkAtAsync(location);
     }
 
     /**


### PR DESCRIPTION
teleport and terrain checking was not using the correct thread. I see there are a bunch of PRs trying to handle 26.1. this just fixes it. No overly complicated changes. Just fixes what wasn't working.