### PR TITLE
fix: cache source position at Teleport instantiation to prevent async race condition

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/teleport/Teleport.java
+++ b/common/src/main/java/net/william278/huskhomes/teleport/Teleport.java
@@ -33,6 +33,7 @@ import net.william278.huskhomes.position.Position;
 import net.william278.huskhomes.user.OnlineUser;
 import net.william278.huskhomes.util.TransactionResolver;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -54,6 +55,8 @@ public class Teleport implements Completable {
     protected final List<TransactionResolver.Action> actions;
     private final boolean async;
     protected final boolean updateLastPosition;
+    @Nullable
+    protected final Position sourcePosition;
 
     protected Teleport(@NotNull OnlineUser executor, @NotNull Teleportable teleporter, @NotNull Target target,
                        @NotNull Type type, boolean updateLastPosition,
@@ -69,6 +72,7 @@ public class Teleport implements Completable {
                 .map(command -> executor.hasPermission(command.getPermission())
                         && executor.hasPermission(command.getPermission("previous")))
                 .orElse(false);
+        this.sourcePosition = (teleporter instanceof OnlineUser online) ? online.getPosition() : null;
     }
 
     @NotNull
@@ -97,8 +101,9 @@ public class Teleport implements Completable {
             if (localTarget.isPresent()) {
                 fireEvent((event) -> {
                     performTransactions();
-                    if (updateLastPosition && canReturnToWorld(teleporter)) {
-                        plugin.getDatabase().setLastPosition(teleporter, teleporter.getPosition());
+                    if (updateLastPosition && sourcePosition != null
+                            && canReturnToWorld(sourcePosition)) {
+                        plugin.getDatabase().setLastPosition(teleporter, sourcePosition);
                     }
                     teleporter.teleportLocally(localTarget.get().getPosition(), async);
                     this.displayTeleportingComplete(teleporter);
@@ -123,8 +128,9 @@ public class Teleport implements Completable {
 
         fireEvent((event) -> {
             performTransactions();
-            if (updateLastPosition && canReturnToWorld(teleporter)) {
-                plugin.getDatabase().setLastPosition(teleporter, teleporter.getPosition());
+            if (updateLastPosition && sourcePosition != null
+                    && canReturnToWorld(sourcePosition)) {
+                plugin.getDatabase().setLastPosition(teleporter, sourcePosition);
             }
 
             final Position target = (Position) this.target;
@@ -166,8 +172,8 @@ public class Teleport implements Completable {
         }));
     }
 
-    private boolean canReturnToWorld(@NotNull OnlineUser user) {
-        return plugin.getSettings().getGeneral().getBackCommand().canReturnToWorld(user.getPosition().getWorld());
+    private boolean canReturnToWorld(@NotNull Position position) {
+        return plugin.getSettings().getGeneral().getBackCommand().canReturnToWorld(position.getWorld());
     }
 
     @NotNull


### PR DESCRIPTION
## Summary

When teleporting asynchronously on Folia (or any async platform), a race condition can occur: the player may move between the time the teleport command is issued and the time the async callback actually executes. This caused `/back` to restore the player to their position at execution time rather than their position at command-invocation time.

## Changes

- `common/src/main/java/net/william278/huskhomes/teleport/Teleport.java`
  - Capture `sourcePosition` immediately in the `Teleport` constructor, before the async dispatch
  - Store it as a `final` field annotated with `@Nullable` (null when the teleporter is a `Username` reference, not an online player)
  - Use the captured `sourcePosition` when calling `setLastPosition` instead of re-reading `teleporter.getPosition()` at execution time
  - Refactor `canReturnToWorld()` to accept a `Position` directly instead of an `OnlineUser`, removing the implicit live-position lookup

## Related

Part of the broader Folia 26.1.2 compatibility work tracked in #980.
Extracted from #987 as requested by maintainers — this change covers only the `/back` race condition fix.