### PR TITLE
fix: refactor RTP location search to non-blocking async recursion

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/random/NormalDistributionEngine.java
+++ b/common/src/main/java/net/william278/huskhomes/random/NormalDistributionEngine.java
@@ -131,17 +131,20 @@ public final class NormalDistributionEngine extends RandomTeleportEngine {
 
     @Override
     public CompletableFuture<Optional<Position>> getRandomPosition(@NotNull World world, @NotNull String[] args) {
-        return plugin.supplyAsync(() -> {
-            Optional<Location> location = generateSafeLocation(world).join();
-            int attempts = 0;
-            while (location.isEmpty()) {
-                location = generateSafeLocation(world).join();
-                if (attempts >= maxAttempts) {
-                    return Optional.empty();
-                }
-                attempts++;
+        return attemptRandomPosition(world, 0);
+    }
+
+    private CompletableFuture<Optional<Position>> attemptRandomPosition(@NotNull World world, int attempt) {
+        if (attempt > maxAttempts) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        return generateSafeLocation(world).thenCompose(location -> {
+            if (location.isPresent()) {
+                return CompletableFuture.completedFuture(
+                        location.map(resolved -> Position.at(resolved, plugin.getServerName()))
+                );
             }
-            return location.map(resolved -> Position.at(resolved, plugin.getServerName()));
+            return attemptRandomPosition(world, attempt + 1);
         });
     }
 }


### PR DESCRIPTION
## Summary

`NormalDistributionEngine` used a blocking `while` loop inside `CompletableFuture.supplyAsync()` with `.join()` calls to retry finding a safe RTP location. On Folia, this occupies an async worker thread for an unbounded number of iterations, which can exhaust the thread pool and cause teleport failures or server-wide slowdowns.

## Changes

- `common/src/main/java/net/william278/huskhomes/random/NormalDistributionEngine.java`
  - Extract `attemptRandomPosition(World, int)` helper that returns a `CompletableFuture`
  - Replace the blocking `while + .join()` loop with tail-recursive `thenCompose()` chaining, so each retry is scheduled asynchronously without holding a thread between attempts
  - The `maxAttempts` guard is preserved — when exceeded, the future completes with `Optional.empty()`

## Related

Part of the broader Folia 26.1.2 compatibility work tracked in #980.
Extracted from #987 as requested by maintainers — this change covers only the RTP non-blocking retry fix.