### PR TITLE
add new maintainers to credits

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/command/HuskHomesCommand.java
+++ b/common/src/main/java/net/william278/huskhomes/command/HuskHomesCommand.java
@@ -78,6 +78,10 @@ public class HuskHomesCommand extends Command implements UserListTabCompletable 
                 .version(plugin.getPluginVersion())
                 .credits("Author",
                         AboutMenu.Credit.of("William278").description("Click to visit website").url("https://william278.net"))
+                .credits("Maintainers",
+                        AboutMenu.Credit.of("QarthO").description("Click to visit their GitHub").url("https://github.com/QarthO"),
+                        AboutMenu.Credit.of("TrueWinter").description("Click to visit their GitHub").url("https://github.com/TrueWinter"))
+                           
                 .credits("Contributors",
                         AboutMenu.Credit.of("imDaniX").description("Code, refactoring"),
                         AboutMenu.Credit.of("Log1x").description("Code"))


### PR DESCRIPTION
add @TrueWinter and I to the maintainer list inside the plugin help. For now the click action links to our respective GitHub accounts (feel free to change before merging)
<img width="542" height="186" alt="image" src="https://github.com/user-attachments/assets/f3dbd324-d135-48f2-ad61-5e4d7de928b8" />
