### PR TITLE
Fix Folia local teleport handling

### DIFF
--- a/bukkit/src/main/java/net/william278/huskhomes/user/BukkitUser.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/user/BukkitUser.java
@@ -34,6 +34,8 @@ import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -45,6 +47,8 @@ import java.util.stream.Collectors;
 public class BukkitUser extends OnlineUser {
 
     private static final String VANISHED_META_KEY = "vanished";
+    private static final Method PLAYER_TELEPORT_ASYNC_METHOD = getPlayerTeleportAsyncMethod();
+
     private final NamespacedKey INVULNERABLE_KEY = new NamespacedKey((BukkitHuskHomes) plugin, "invulnerable");
     private final Player bukkitPlayer;
 
@@ -127,12 +131,40 @@ public class BukkitUser extends OnlineUser {
             bukkitPlayer.leaveVehicle();
             bukkitPlayer.eject();
             bukkitPlayer.setFallDistance(0f);
-            if (async || ((BukkitHuskHomes) plugin).getScheduler().isUsingFolia()) {
+            if (((BukkitHuskHomes) plugin).getScheduler().isUsingFolia()) {
+                teleportAsync(location);
+                return;
+            }
+            if (async) {
                 PaperLib.teleportAsync(bukkitPlayer, location, PlayerTeleportEvent.TeleportCause.PLUGIN);
                 return;
             }
             bukkitPlayer.teleport(location, PlayerTeleportEvent.TeleportCause.PLUGIN);
         }, this);
+    }
+
+    private void teleportAsync(@NotNull org.bukkit.Location location) {
+        if (PLAYER_TELEPORT_ASYNC_METHOD == null) {
+            throw new IllegalStateException("Folia requires Player#teleportAsync(Location, TeleportCause)");
+        }
+
+        try {
+            PLAYER_TELEPORT_ASYNC_METHOD.invoke(bukkitPlayer, location, PlayerTeleportEvent.TeleportCause.PLUGIN);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("Could not access Player#teleportAsync(Location, TeleportCause)", e);
+        } catch (InvocationTargetException e) {
+            throw new IllegalStateException("Failed to teleport player asynchronously", e.getCause());
+        }
+    }
+
+    private static Method getPlayerTeleportAsyncMethod() {
+        try {
+            return Player.class.getMethod(
+                    "teleportAsync", org.bukkit.Location.class, PlayerTeleportEvent.TeleportCause.class
+            );
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Add a Folia-specific local teleport path that calls Paper's Player#teleportAsync(Location, TeleportCause) API directly via reflection.

On Folia, HuskHomes schedules local teleports through the entity scheduler, but PaperLib can still fall back to a synchronous Entity#teleport(...) call. Since Folia does not allow synchronous teleports from a region thread, this caused local teleports to fail with:

```
java.lang.UnsupportedOperationException: Must use teleportAsync while in region threading
    at org.bukkit.craftbukkit.entity.CraftPlayer.teleport0(...)
    at org.bukkit.craftbukkit.entity.CraftEntity.teleport(...)
    at net.william278.huskhomes.libraries.paperlib.features.asyncteleport.AsyncTeleportSync.teleportAsync(...)
    at net.william278.huskhomes.user.BukkitUser.lambda$teleportLocally$3(...)
```

Non-Folia behavior is unchanged, async local teleports still use PaperLib.teleportAsync(...) and sync local teleports still use Player#teleport(...)

## Testing
- Built with ./gradlew.bat --configure-on-demand :paper:build --no-daemon
- Tested on Folia 26.1.2, /tp no longer throws the region-threading teleport exception
