### PR TITLE
Use native Paper teleportAsync on Paper/Folia

### DIFF
--- a/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
@@ -59,6 +59,7 @@ import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.java.JavaPluginLoader;
@@ -75,6 +76,7 @@ import space.arim.morepaperlib.scheduling.RegionalScheduler;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 @Getter
@@ -315,6 +317,20 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes, BukkitTask
     @NotNull
     public AttachedScheduler getUserSyncScheduler(@NotNull OnlineUser user) {
         return getScheduler().entitySpecificScheduler(((BukkitUser) user).getPlayer());
+    }
+
+    public boolean isUsingFolia() {
+        return getScheduler().isUsingFolia();
+    }
+
+    @NotNull
+    public CompletableFuture<Boolean> teleportPlayer(@NotNull Player player, @NotNull org.bukkit.Location location,
+                                                     @NotNull PlayerTeleportEvent.TeleportCause cause,
+                                                     boolean async) {
+        if (async || isUsingFolia()) {
+            return io.papermc.lib.PaperLib.teleportAsync(player, location, cause);
+        }
+        return CompletableFuture.completedFuture(player.teleport(location, cause));
     }
 
     @Override

--- a/bukkit/src/main/java/net/william278/huskhomes/user/BukkitUser.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/user/BukkitUser.java
@@ -19,7 +19,6 @@
 
 package net.william278.huskhomes.user;
 
-import io.papermc.lib.PaperLib;
 import net.william278.huskhomes.BukkitHuskHomes;
 import net.william278.huskhomes.network.PluginMessageBroker;
 import net.william278.huskhomes.position.Location;
@@ -127,11 +126,9 @@ public class BukkitUser extends OnlineUser {
             bukkitPlayer.leaveVehicle();
             bukkitPlayer.eject();
             bukkitPlayer.setFallDistance(0f);
-            if (async || ((BukkitHuskHomes) plugin).getScheduler().isUsingFolia()) {
-                PaperLib.teleportAsync(bukkitPlayer, location, PlayerTeleportEvent.TeleportCause.PLUGIN);
-                return;
-            }
-            bukkitPlayer.teleport(location, PlayerTeleportEvent.TeleportCause.PLUGIN);
+            ((BukkitHuskHomes) plugin).teleportPlayer(
+                    bukkitPlayer, location, PlayerTeleportEvent.TeleportCause.PLUGIN, async
+            );
         }, this);
     }
 

--- a/paper/src/main/java/net/william278/huskhomes/PaperHuskHomes.java
+++ b/paper/src/main/java/net/william278/huskhomes/PaperHuskHomes.java
@@ -21,9 +21,12 @@ package net.william278.huskhomes;
 
 import net.kyori.adventure.audience.Audience;
 import net.william278.huskhomes.listener.PaperEventListener;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.UUID;
 
 public class PaperHuskHomes extends BukkitHuskHomes {
@@ -39,5 +42,16 @@ public class PaperHuskHomes extends BukkitHuskHomes {
     public Audience getAudience(@NotNull UUID user) {
         final Player player = getServer().getPlayer(user);
         return player == null || !player.isOnline() ? Audience.empty() : player;
+    }
+
+    @Override
+    @NotNull
+    public CompletableFuture<Boolean> teleportPlayer(@NotNull Player player, @NotNull Location location,
+                                                     @NotNull PlayerTeleportEvent.TeleportCause cause,
+                                                     boolean async) {
+        if (async || isUsingFolia()) {
+            return player.teleportAsync(location, cause);
+        }
+        return CompletableFuture.completedFuture(player.teleport(location, cause));
     }
 }


### PR DESCRIPTION
Fixes teleport failures on Folia-compatible region-threaded servers where PaperLib may fall back to synchronous
Entity#teleport, causing "Must use teleportAsync while in region threading".

This delegates Bukkit teleport behavior through the platform plugin class and overrides it on Paper to call
Player#teleportAsync directly when async teleporting or running on Folia.