### PR TITLE
Add Fand platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 **HuskHomes** is a powerful, intuitive and flexible teleportation plugin for _Minecraft: Java Edition_ servers. HuskHomes contains a meaty&mdash;but not bloated&mdash;set of player teleportation features, including set homes, warps, public homes, teleport requests, previous and offline position teleporting&mdash;and more. 
 
-HuskHomes can be used on your Spigot or Fabric server, and with a MySQL Database even works cross-server, letting players teleport across your proxy (Bungee or Velocity) network!  
+HuskHomes can be used on your Spigot, Fabric, or Fand server, and with a MySQL Database even works cross-server, letting players teleport across your proxy (Bungee or Velocity) network!
 
 ## Features
 **⭐ Works cross-server** &mdash; Let players seamlessly teleport and set homes across your proxies network of servers using MySQL/MariaDB.

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ allprojects {
         maven { url 'https://repo.essentialsx.net/releases/' }
         maven { url 'https://repo.mikeprimm.com/' }
         maven { url 'https://maven.impactdev.net/repository/development' }
+        maven { url 'https://repo.fandmc.cn/repository/maven-public/' }
     }
 
     dependencies {
@@ -158,7 +159,7 @@ subprojects {
     }
 
     // API publishing
-    if (['common', 'bukkit'].contains(project.name) || project.parent?.name?.equals('fabric')) {
+    if (['common', 'bukkit', 'fand'].contains(project.name) || project.parent?.name?.equals('fabric')) {
         java {
             withSourcesJar()
             withJavadocJar()
@@ -190,6 +191,19 @@ subprojects {
                     mavenJavaBukkit(MavenPublication) {
                         groupId = 'net.william278.huskhomes'
                         artifactId = 'huskhomes-bukkit'
+                        version = "$rootProject.version"
+                        artifact shadowJar
+                        artifact sourcesJar
+                        artifact javadocJar
+                    }
+                }
+            }
+
+            if (['fand'].contains(project.name)) {
+                publications {
+                    mavenJavaFand(MavenPublication) {
+                        groupId = 'net.william278.huskhomes'
+                        artifactId = 'huskhomes-fand'
                         version = "$rootProject.version"
                         artifact shadowJar
                         artifact sourcesJar

--- a/common/src/main/java/net/william278/huskhomes/util/AudiencesProvider.java
+++ b/common/src/main/java/net/william278/huskhomes/util/AudiencesProvider.java
@@ -36,13 +36,16 @@ import java.util.UUID;
 public interface AudiencesProvider {
 
     /**
-     * Get the {@link Audiences} instance.
+     * Get the platform {@link Audiences} instance, when one is available.
      *
      * @return the {@link Audiences} instance
+     * @throws UnsupportedOperationException if the platform uses Adventure directly without a platform adapter
      * @since 4.8
      */
     @NotNull
-    AudienceProvider getAudiences();
+    default AudienceProvider getAudiences() {
+        throw new UnsupportedOperationException("This platform does not expose an Adventure AudienceProvider");
+    }
 
     /**
      * Get the {@link Audience} instance for the given {@link OnlineUser}.

--- a/docs/API-Events.md
+++ b/docs/API-Events.md
@@ -39,3 +39,17 @@ HomeCreateCallback.EVENT.register((player, home) -> {
 });.
 ```
 </details>
+
+## Events on Fand
+> **Note:** Target the `huskhomes-fand` artifact described in the [[API]] introduction.
+
+Fand publishes every HuskHomes API event through the plugin event bus as a `FandHuskHomesEvent`. Its `event()` payload is one of the common event interfaces listed above; mutations and cancellation are applied to the operation being processed.
+
+```java
+context.events().subscribe(FandHuskHomesEvent.class, event -> {
+    if (event.event() instanceof IHomeCreateEvent homeCreate) {
+        homeCreate.setName(homeCreate.getName().toLowerCase(Locale.ROOT));
+        // homeCreate.setCancelled(true);
+    }
+});
+```

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,6 +21,7 @@ The HuskHomes API is available for the following platforms:
 
 * `bukkit` - Bukkit, Spigot, Paper, etc. Provides Bukkit API event listeners and adapters to `org.bukkit` objects.
 * `fabric` - Fabric, Quilt, etc. Provides Fabric API event callbacks and adapters to `net.minecraft` objects.
+* `fand` - Fand Server. Provides Fand event-bus integration and adapters to `io.fand.api` objects.
 * `common` - Common API for all platforms.
 
 <details>
@@ -84,7 +85,7 @@ dependencies {
 </details>
 
 ## 2 Adding HuskHomes as a dependency
-Add HuskHomes to your `softdepend` (if you want to optionally use HuskHomes) or `depend` (if your plugin relies on HuskHomes) section in `plugin.yml` of your project.
+Add HuskHomes to your platform's plugin dependency metadata. Bukkit plugins use `softdepend` or `depend` in `plugin.yml`. Fand plugins that directly use HuskHomes Java API types must use `depends` in `fand-plugin.json`; `loadAfter` only controls order and does not grant class-loader visibility.
 
 ```yaml
 name: MyPlugin
@@ -94,6 +95,14 @@ author: William278
 description: 'A plugin that hooks with the HuskHomes API!'
 softdepend: # Or, use 'depend' here
   - HuskHomes
+```
+
+For Fand, use the lowercase plugin id:
+
+```json
+{
+  "depends": ["huskhomes"]
+}
 ```
 
 ## 3 Next steps

--- a/docs/Config-Files.md
+++ b/docs/Config-Files.md
@@ -1,7 +1,7 @@
 This page contains the configuration structure for HuskHomes.
 
 ## Configuration structure
-📁 `plugins/HuskHomes/` (Spigot) OR `config/huskhomes/` (Fabric)
+📁 `plugins/HuskHomes/` (Spigot), `config/huskhomes/` (Fabric), or `plugins/huskhomes/` (Fand)
   - 📄 `config.yml`: General plugin configuration
   - 📄 `server.yml`: (Cross-server setups only) Server ID configuration
   - 📄 `spawn.yml`: Local saved server spawn position. Use /setspawn to generate this file

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -3,7 +3,7 @@ This will walk you through installing HuskHomes on your Spigot, Fabric, or Fand 
 ## Requirements
 > **Note:** If the plugin fails to load, please check that you are not running an [incompatible version combination](Compatibility)
 
-* A Spigot (1.17.1+), Fabric (latest Minecraft version), or Fand 0.7.2+ _Minecraft: Java Edition_ server. Fand requires Java 25.
+* A Spigot (1.17.1+), Fabric (latest Minecraft version), or Fand 0.7.4+ _Minecraft: Java Edition_ server. Fand requires Java 25.
 * (For proxy network support) A proxy server (Velocity, BungeeCord) and MySQL (v8.0+)/MariaDB/PostgreSQL database
 * (For optional [[Redis support]]) A Redis database (v5.0+)
 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -1,9 +1,9 @@
-This will walk you through installing HuskHomes on your Spigot or Fabric server, or proxy network of servers.
+This will walk you through installing HuskHomes on your Spigot, Fabric, or Fand server, or proxy network of servers.
 
 ## Requirements
 > **Note:** If the plugin fails to load, please check that you are not running an [incompatible version combination](Compatibility)
 
-* A Spigot (1.17.1+) or Fabric (latest Minecraft version) _Minecraft: Java Edition_ server running on Java 17+
+* A Spigot (1.17.1+), Fabric (latest Minecraft version), or Fand 0.7.2+ _Minecraft: Java Edition_ server. Fand requires Java 25.
 * (For proxy network support) A proxy server (Velocity, BungeeCord) and MySQL (v8.0+)/MariaDB/PostgreSQL database
 * (For optional [[Redis support]]) A Redis database (v5.0+)
 
@@ -11,12 +11,13 @@ This will walk you through installing HuskHomes on your Spigot or Fabric server,
 Download the correct jar file for your server from the [latest release page](https://github.com/WiIIiam278/HuskHomes/releases/latest):
 * the `HuskHomes-Paper` jar for Spigot or Paper servers
 * the `HuskHomes-Fabric` jar for Fabric servers
+* the `HuskHomes-Fand` jar for Fand servers
 
 ## Single-server Setup Instructions
-These instructions are for simply installing HuskHomes on one Spigot or Fabric server.
+These instructions are for simply installing HuskHomes on one supported server.
 
 ### 1. Install the jar
-- Place the plugin jar file in the `/plugins/` directory of your Spigot server, or the `/mods` directory of your Fabric server.
+- Place the plugin jar file in the `/plugins/` directory of your Spigot or Fand server, or the `/mods` directory of your Fabric server.
 ### 2. Restart the server and configure
 - Start, then stop your server to let HuskHomes generate the config file.
 - You can now edit the [config](Config-Files) and locales to your liking.
@@ -26,16 +27,16 @@ These instructions are for simply installing HuskHomes on one Spigot or Fabric s
 -----
 
 ## Multi-server Setup Instructions
-These instructions are for installing HuskHomes on multiple Spigot or Fabric servers and having them network together. A MySQL database (v8.0+) is required.
+These instructions are for installing HuskHomes on multiple supported servers and having them network together. A MySQL database (v8.0+) is required.
 
 ### 1. Install the jar
-- Place the plugin jar file in the `/plugins/` directory of each Spigot server, or the `/mods` directory of your Fabric server.
+- Place the plugin jar file in the `/plugins/` directory of each Spigot or Fand server, or the `/mods` directory of each Fabric server.
 - You do not need to install HuskHomes as a proxy plugin.
 ### 2. Restart the server and configure
 - Start, then stop every server to let HuskHomes generate the config file.
-- Advanced users: If you'd prefer, you can just create one config.yml file and create symbolic links in each `/plugins/HuskHomes/` (`/config/huskhomes/` on Fabric) folder to it to make updating it easier.
+- Advanced users: If you'd prefer, you can just create one config.yml file and create symbolic links in each `/plugins/HuskHomes/` (`/config/huskhomes/` on Fabric, `/plugins/huskhomes/` on Fand) folder to it to make updating it easier.
 ### 3. Configure servers to use cross-server mode
-- Navigate to the HuskHomes [config](Config-Files) file on each server (`~/plugins/HuskHomes/config.yml` on Spigot, `~/config/huskhomes/config.yml` on Fabric)
+- Navigate to the HuskHomes [config](Config-Files) file on each server (`~/plugins/HuskHomes/config.yml` on Spigot, `~/config/huskhomes/config.yml` on Fabric, `~/plugins/huskhomes/config.yml` on Fand)
 - Under `database`, set `type` to `MYSQL`, `MARIADB` or `POSTGRESQL` (depending on which type of database you wish to use)
 - Under `mysql`/`credentials`, enter the credentials of your MySQL, MariaDB or PostgreSQL database server.
 - Scroll down and look for the `cross_server` section. Set `enabled` to `true`.

--- a/fand/build.gradle
+++ b/fand/build.gradle
@@ -15,10 +15,10 @@ dependencies {
     implementation project(':common')
     implementation 'net.william278.toilet:toilet-common:1.1.0'
 
-    compileOnly 'io.fand:fand-api:0.7.2+build.1'
+    compileOnly 'io.fand:fand-api:0.7.4+build.1'
     compileOnly 'org.jetbrains:annotations:26.1.0'
 
-    testImplementation 'io.fand:fand-api:0.7.2+build.1'
+    testImplementation 'io.fand:fand-api:0.7.4+build.1'
 }
 
 shadowJar {

--- a/fand/build.gradle
+++ b/fand/build.gradle
@@ -1,0 +1,40 @@
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+
+plugins {
+    id 'java-library'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+compileJava.options.release.set 25
+
+dependencies {
+    implementation project(':common')
+    implementation 'net.william278.toilet:toilet-common:1.1.0'
+
+    compileOnly 'io.fand:fand-api:0.7.2+build.1'
+    compileOnly 'org.jetbrains:annotations:26.1.0'
+
+    testImplementation 'io.fand:fand-api:0.7.2+build.1'
+}
+
+shadowJar {
+    mergeServiceFiles()
+
+    relocate 'org.apache.commons.io', 'net.william278.huskhomes.libraries.commons.io'
+    relocate 'org.apache.commons.text', 'net.william278.huskhomes.libraries.commons.text'
+    relocate 'org.apache.commons.lang3', 'net.william278.huskhomes.libraries.commons.lang3'
+    relocate 'de.themoep', 'net.william278.huskhomes.libraries'
+    relocate 'com.zaxxer', 'net.william278.huskhomes.libraries'
+    relocate 'net.william278.paginedown', 'net.william278.huskhomes.libraries.paginedown'
+    relocate 'net.william278.desertwell', 'net.william278.huskhomes.libraries.desertwell'
+    relocate 'net.william278.toilet', 'net.william278.huskhomes.libraries.toilet'
+    relocate 'de.exlll.configlib', 'net.william278.huskhomes.libraries.configlib'
+    relocate 'org.yaml.snakeyaml', 'net.william278.huskhomes.libraries.snakeyaml'
+    relocate 'org.json', 'net.william278.huskhomes.libraries.json'
+    relocate 'com.google.gson', 'net.william278.huskhomes.libraries.gson'
+    relocate 'com.fatboyindustrial', 'net.william278.huskhomes.libraries.gsonjavatime'
+}

--- a/fand/src/main/java/net/william278/huskhomes/FandAdapter.java
+++ b/fand/src/main/java/net/william278/huskhomes/FandAdapter.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes;
+
+import io.fand.api.entity.Player;
+import net.kyori.adventure.key.Key;
+import net.william278.huskhomes.position.Location;
+import net.william278.huskhomes.position.Position;
+import net.william278.huskhomes.position.World;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
+
+public final class FandAdapter {
+
+    private FandAdapter() {
+    }
+
+    @NotNull
+    public static Location adapt(@NotNull io.fand.api.world.Location location) {
+        return Location.at(
+                location.x(), location.y(), location.z(), location.yaw(), location.pitch(), adapt(location.world())
+        );
+    }
+
+    @NotNull
+    public static Position adapt(@NotNull io.fand.api.world.Location location, @NotNull String server) {
+        return Position.at(adapt(location), server);
+    }
+
+    @NotNull
+    public static World adapt(@NotNull io.fand.api.world.World world) {
+        final String name = world.key().asMinimalString();
+        return World.from(
+                name,
+                UUID.nameUUIDFromBytes(world.key().asString().getBytes(StandardCharsets.UTF_8)),
+                World.Environment.match(name)
+        );
+    }
+
+    @NotNull
+    public static Optional<? extends io.fand.api.world.World> adapt(@NotNull World world,
+                                                                    @NotNull io.fand.api.Server server) {
+        return server.world(Key.key(world.getName()));
+    }
+
+    @NotNull
+    public static Optional<io.fand.api.world.Location> adapt(@NotNull Location location,
+                                                             @NotNull io.fand.api.Server server) {
+        return adapt(location.getWorld(), server).map(world -> world.at(
+                location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch()
+        ));
+    }
+
+    @NotNull
+    public static Position adapt(@NotNull Player player, @NotNull String server) {
+        return adapt(player.location(), server);
+    }
+}

--- a/fand/src/main/java/net/william278/huskhomes/FandHuskHomes.java
+++ b/fand/src/main/java/net/william278/huskhomes/FandHuskHomes.java
@@ -1,0 +1,440 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes;
+
+import io.fand.api.messaging.PluginMessageDirection;
+import io.fand.api.permission.PermissionDefault;
+import io.fand.api.permission.PermissionDescriptor;
+import io.fand.api.plugin.Plugin;
+import io.fand.api.plugin.PluginContext;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.william278.desertwell.util.Version;
+import net.william278.huskhomes.api.FandHuskHomesAPI;
+import net.william278.huskhomes.command.Command;
+import net.william278.huskhomes.command.FandCommand;
+import net.william278.huskhomes.config.Locales;
+import net.william278.huskhomes.config.Server;
+import net.william278.huskhomes.config.Settings;
+import net.william278.huskhomes.config.Spawn;
+import net.william278.huskhomes.database.Database;
+import net.william278.huskhomes.event.FandEventDispatcher;
+import net.william278.huskhomes.hook.FandHookProvider;
+import net.william278.huskhomes.hook.Hook;
+import net.william278.huskhomes.listener.EventListener;
+import net.william278.huskhomes.listener.FandEventListener;
+import net.william278.huskhomes.manager.Manager;
+import net.william278.huskhomes.network.Broker;
+import net.william278.huskhomes.network.PluginMessageBroker;
+import net.william278.huskhomes.position.Position;
+import net.william278.huskhomes.position.World;
+import net.william278.huskhomes.random.RandomTeleportEngine;
+import net.william278.huskhomes.user.FandUserProvider;
+import net.william278.huskhomes.user.OnlineUser;
+import net.william278.huskhomes.user.SavedUser;
+import net.william278.huskhomes.user.User;
+import net.william278.huskhomes.user.ConsoleUser;
+import net.william278.huskhomes.util.FandSavePositionProvider;
+import net.william278.huskhomes.util.FandTask;
+import net.william278.huskhomes.util.UnsafeBlocks;
+import net.william278.toilet.Toilet;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+public final class FandHuskHomes implements Plugin, HuskHomes, FandTask.Supplier, FandEventDispatcher,
+        FandSavePositionProvider, FandUserProvider, FandHookProvider {
+
+    private final Set<SavedUser> savedUsers = ConcurrentHashMap.newKeySet();
+    private final Set<UUID> currentlyOnWarmup = ConcurrentHashMap.newKeySet();
+    private final Set<UUID> warmupDamagedUsers = ConcurrentHashMap.newKeySet();
+    private final Map<UUID, OnlineUser> onlineUserMap = new ConcurrentHashMap<>();
+    private final Map<String, List<User>> globalUserList = new ConcurrentHashMap<>();
+    private final Map<String, Boolean> permissions = new ConcurrentHashMap<>();
+    private final List<Command> commands = new ArrayList<>();
+    private final Audience consoleAudience = new Audience() {
+        @Override
+        public void sendMessage(@NotNull Component message) {
+            context.logger().info("{}", message);
+        }
+    };
+
+    private PluginContext context;
+    private Toilet toilet;
+    private Set<Hook> hooks = new HashSet<>();
+    private Settings settings;
+    private Locales locales;
+    private Database database;
+    private Manager manager;
+    private EventListener eventListener;
+    private RandomTeleportEngine randomTeleportEngine;
+    private Spawn serverSpawn;
+    private UnsafeBlocks unsafeBlocks;
+    private @Nullable Broker broker;
+    private @Nullable Server serverName;
+    private boolean active;
+    private boolean failed;
+
+    @Override
+    public void onLoad(@NotNull PluginContext context) {
+        this.context = context;
+        this.load();
+        if (failed) {
+            throw new IllegalStateException("HuskHomes failed to load");
+        }
+    }
+
+    @Override
+    public void onEnable(@NotNull PluginContext context) {
+        if (failed) {
+            return;
+        }
+        this.toilet = FandToilet.create(getDumpOptions(), this);
+        this.active = true;
+        this.enable();
+        if (failed) {
+            throw new IllegalStateException("HuskHomes failed to enable");
+        }
+        try {
+            this.loadCommands();
+        } catch (RuntimeException | Error failure) {
+            log(Level.SEVERE, "Failed to register HuskHomes commands", failure);
+            disablePlugin();
+            throw failure;
+        }
+    }
+
+    @Override
+    public void onDisable(@NotNull PluginContext context) {
+        if (active) {
+            this.shutdown();
+            this.active = false;
+        }
+    }
+
+    @NotNull
+    public PluginContext getContext() {
+        return context;
+    }
+
+    @Override
+    public void loadAPI() {
+        FandHuskHomesAPI.register(this);
+    }
+
+    @Override
+    public void loadMetrics() {
+    }
+
+    @Override
+    public void disablePlugin() {
+        failed = true;
+        if (active) {
+            shutdown();
+            active = false;
+        }
+    }
+
+    @Override
+    public void setWorldSpawn(@NotNull Position position) {
+        FandAdapter.adapt(position.getWorld(), server()).ifPresent(world ->
+                world.setSpawnLocation(world.at(
+                        position.getX(), position.getY(), position.getZ(), position.getYaw(), position.getPitch()
+                ))
+        );
+    }
+
+    @Override
+    public void setServerName(@NotNull Server serverName) {
+        this.serverName = serverName;
+    }
+
+    @Override
+    @Nullable
+    public InputStream getResource(@NotNull String name) {
+        return getClass().getClassLoader().getResourceAsStream(name);
+    }
+
+    @Override
+    @NotNull
+    public Path getConfigDirectory() {
+        return context.dataDirectory();
+    }
+
+    @Override
+    @NotNull
+    public List<World> getWorlds() {
+        return server().worlds().stream().map(FandAdapter::adapt).toList();
+    }
+
+    @Override
+    public void registerCommands(@NotNull List<Command> toRegister) {
+        toRegister.forEach(command -> {
+            commands.add(command);
+            registerPermission(command.getPermission(), command.isOperatorCommand());
+            command.getAdditionalPermissions().forEach(this::registerPermission);
+            new FandCommand(command, this).register();
+        });
+    }
+
+    private void registerPermission(@NotNull String permission, boolean operatorOnly) {
+        if (permissions.putIfAbsent(permission, operatorOnly) == null) {
+            context.permissions().register(new PermissionDescriptor(
+                    permission, operatorOnly ? PermissionDefault.OPERATOR : PermissionDefault.TRUE
+            ));
+        }
+    }
+
+    @Override
+    @NotNull
+    public EventListener createListener() {
+        this.eventListener = new FandEventListener(this);
+        return eventListener;
+    }
+
+    @Override
+    public void setupPluginMessagingChannels() {
+        context.pluginMessaging().register(
+                Key.key("bungeecord", "main"),
+                PluginMessageDirection.BIDIRECTIONAL,
+                (player, channel, payload) -> {
+                    if (broker instanceof PluginMessageBroker messenger
+                            && settings.getCrossServer().getBrokerType() == Broker.Type.PLUGIN_MESSAGE) {
+                        messenger.onReceive(PluginMessageBroker.BUNGEE_CHANNEL_ID, getOnlineUser(player), payload);
+                    }
+                }
+        );
+    }
+
+    @Override
+    public void log(@NotNull Level level, @NotNull String message, Throwable... exceptions) {
+        final Throwable failure = exceptions.length == 0 ? null : exceptions[0];
+        if (level.intValue() >= Level.SEVERE.intValue()) {
+            if (failure == null) {
+                context.logger().error(message);
+            } else {
+                context.logger().error(message, failure);
+            }
+        } else if (level.intValue() >= Level.WARNING.intValue()) {
+            if (failure == null) {
+                context.logger().warn(message);
+            } else {
+                context.logger().warn(message, failure);
+            }
+        } else {
+            if (failure == null) {
+                context.logger().info(message);
+            } else {
+                context.logger().info(message, failure);
+            }
+        }
+    }
+
+    @Override
+    public void closeDatabase() {
+        if (database != null) {
+            database.close();
+        }
+    }
+
+    @Override
+    public void closeBroker() {
+        if (broker != null) {
+            broker.close();
+        }
+    }
+
+    @Override
+    @NotNull
+    public Version getPluginVersion() {
+        return Version.fromString(context.descriptor().version(), "-");
+    }
+
+    @Override
+    @NotNull
+    public String getServerType() {
+        return "fand %s/%s".formatted(server().version(), server().minecraftVersion());
+    }
+
+    @Override
+    @NotNull
+    public Version getMinecraftVersion() {
+        return Version.fromString(server().minecraftVersion());
+    }
+
+    @Override
+    @NotNull
+    public Audience getAudience(@NotNull UUID user) {
+        return server().player(user).map(player -> (Audience) player).orElse(Audience.empty());
+    }
+
+    @Override
+    @NotNull
+    public ConsoleUser getConsole() {
+        return ConsoleUser.wrap(consoleAudience);
+    }
+
+    @Override
+    @NotNull
+    public Toilet getToilet() {
+        return toilet;
+    }
+
+    @Override
+    @NotNull
+    public FandHuskHomes getPlugin() {
+        return this;
+    }
+
+    public Map<String, Boolean> getPermissions() {
+        return permissions;
+    }
+
+    @Override
+    public Map<UUID, OnlineUser> getOnlineUserMap() {
+        return onlineUserMap;
+    }
+
+    @Override
+    public Map<String, List<User>> getGlobalUserList() {
+        return globalUserList;
+    }
+
+    @Override
+    public Set<SavedUser> getSavedUsers() {
+        return savedUsers;
+    }
+
+    @Override
+    public Set<UUID> getCurrentlyOnWarmup() {
+        return currentlyOnWarmup;
+    }
+
+    @Override
+    public Set<UUID> getWarmupDamagedUsers() {
+        return warmupDamagedUsers;
+    }
+
+    @Override
+    public List<Command> getCommands() {
+        return commands;
+    }
+
+    @Override
+    public Set<Hook> getHooks() {
+        return hooks;
+    }
+
+    @Override
+    public void setHooks(@NotNull Set<Hook> hooks) {
+        this.hooks = hooks;
+    }
+
+    @Override
+    public Settings getSettings() {
+        return settings;
+    }
+
+    @Override
+    public void setSettings(@NotNull Settings settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    public Locales getLocales() {
+        return locales;
+    }
+
+    @Override
+    public void setLocales(@NotNull Locales locales) {
+        this.locales = locales;
+    }
+
+    @Override
+    public Database getDatabase() {
+        return database;
+    }
+
+    @Override
+    public void setDatabase(@NotNull Database database) {
+        this.database = database;
+    }
+
+    @Override
+    public Manager getManager() {
+        return manager;
+    }
+
+    @Override
+    public void setManager(@NotNull Manager manager) {
+        this.manager = manager;
+    }
+
+    public EventListener getEventListener() {
+        return eventListener;
+    }
+
+    @Override
+    public RandomTeleportEngine getRandomTeleportEngine() {
+        return randomTeleportEngine;
+    }
+
+    @Override
+    public void setRandomTeleportEngine(@NotNull RandomTeleportEngine randomTeleportEngine) {
+        this.randomTeleportEngine = randomTeleportEngine;
+    }
+
+    @Override
+    public Optional<Spawn> getServerSpawn() {
+        return Optional.ofNullable(serverSpawn);
+    }
+
+    @Override
+    public void setServerSpawn(@NotNull Spawn serverSpawn) {
+        this.serverSpawn = serverSpawn;
+    }
+
+    @Override
+    public UnsafeBlocks getUnsafeBlocks() {
+        return unsafeBlocks;
+    }
+
+    @Override
+    public void setUnsafeBlocks(@NotNull UnsafeBlocks unsafeBlocks) {
+        this.unsafeBlocks = unsafeBlocks;
+    }
+
+    @Override
+    public Optional<Broker> getBroker() {
+        return Optional.ofNullable(broker);
+    }
+
+    @Override
+    public void setBroker(@Nullable Broker broker) {
+        this.broker = broker;
+    }
+
+    @Override
+    @NotNull
+    public String getServerName() {
+        return serverName == null ? "server" : serverName.getName();
+    }
+}

--- a/fand/src/main/java/net/william278/huskhomes/FandToilet.java
+++ b/fand/src/main/java/net/william278/huskhomes/FandToilet.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes;
+
+import net.william278.toilet.DumpOptions;
+import net.william278.toilet.Toilet;
+import net.william278.toilet.dump.PluginInfo;
+import net.william278.toilet.dump.ServerMeta;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.util.List;
+
+final class FandToilet extends Toilet {
+
+    private final FandHuskHomes plugin;
+
+    private FandToilet(@NotNull DumpOptions options, @NotNull FandHuskHomes plugin) {
+        super(options);
+        this.plugin = plugin;
+    }
+
+    static FandToilet create(@NotNull DumpOptions options, @NotNull FandHuskHomes plugin) {
+        return new FandToilet(options, plugin);
+    }
+
+    @Override
+    public List<PluginInfo> getPlugins() {
+        return List.of(PluginInfo.builder()
+                .name(plugin.getContext().descriptor().id())
+                .version(plugin.getContext().descriptor().version())
+                .description(plugin.getContext().descriptor().description())
+                .authors(plugin.getContext().descriptor().authors())
+                .enabled(true)
+                .build());
+    }
+
+    @Override
+    public ServerMeta getServerMeta() {
+        return ServerMeta.builder()
+                .minecraftVersion(plugin.server().minecraftVersion())
+                .serverJarType("fand")
+                .serverJarVersion(plugin.server().version())
+                .proxyState(ServerMeta.ProxyState.NO_PROXY)
+                .onlineMode(true)
+                .build();
+    }
+
+    @Override
+    public Path getProjectConfigDirectory() {
+        return plugin.getConfigDirectory();
+    }
+}

--- a/fand/src/main/java/net/william278/huskhomes/api/FandHuskHomesAPI.java
+++ b/fand/src/main/java/net/william278/huskhomes/api/FandHuskHomesAPI.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes.api;
+
+import io.fand.api.entity.Player;
+import net.william278.huskhomes.FandAdapter;
+import net.william278.huskhomes.FandHuskHomes;
+import net.william278.huskhomes.position.Location;
+import net.william278.huskhomes.position.Position;
+import net.william278.huskhomes.position.World;
+import net.william278.huskhomes.user.FandUser;
+import net.william278.huskhomes.user.OnlineUser;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+
+/**
+ * HuskHomes API adapter for the Fand platform.
+ */
+public final class FandHuskHomesAPI extends BaseHuskHomesAPI {
+
+    private FandHuskHomesAPI(@NotNull FandHuskHomes plugin) {
+        super(plugin);
+    }
+
+    @NotNull
+    public static FandHuskHomesAPI getInstance() throws NotRegisteredException {
+        return (FandHuskHomesAPI) BaseHuskHomesAPI.getInstance();
+    }
+
+    @ApiStatus.Internal
+    public static void register(@NotNull FandHuskHomes plugin) {
+        instance = new FandHuskHomesAPI(plugin);
+    }
+
+    @NotNull
+    public OnlineUser adaptUser(@NotNull Player player) {
+        return ((FandHuskHomes) plugin).getOnlineUser(player);
+    }
+
+    @NotNull
+    public Player getPlayer(@NotNull OnlineUser user) {
+        if (!(user instanceof FandUser fandUser)) {
+            throw new IllegalArgumentException("User is not a Fand user");
+        }
+        return fandUser.getPlayer();
+    }
+
+    @NotNull
+    public Location adaptLocation(@NotNull io.fand.api.world.Location location) {
+        return FandAdapter.adapt(location);
+    }
+
+    @NotNull
+    public Position adaptPosition(@NotNull io.fand.api.world.Location location) {
+        return FandAdapter.adapt(location, getServer());
+    }
+
+    @NotNull
+    public Optional<? extends io.fand.api.world.World> getWorld(@NotNull World world) {
+        return FandAdapter.adapt(world, ((FandHuskHomes) plugin).server());
+    }
+
+    @NotNull
+    public Optional<io.fand.api.world.Location> adaptLocation(@NotNull Location location) {
+        return FandAdapter.adapt(location, ((FandHuskHomes) plugin).server());
+    }
+}

--- a/fand/src/main/java/net/william278/huskhomes/command/FandCommand.java
+++ b/fand/src/main/java/net/william278/huskhomes/command/FandCommand.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes.command;
+
+import io.fand.api.command.Arguments;
+import io.fand.api.command.CommandContext;
+import io.fand.api.command.CommandSender;
+import io.fand.api.entity.Player;
+import net.william278.huskhomes.FandHuskHomes;
+import net.william278.huskhomes.user.CommandUser;
+import net.william278.huskhomes.user.ConsoleUser;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public final class FandCommand {
+
+    private final Command command;
+    private final FandHuskHomes plugin;
+
+    public FandCommand(@NotNull Command command, @NotNull FandHuskHomes plugin) {
+        this.command = command;
+        this.plugin = plugin;
+    }
+
+    public void register() {
+        plugin.getContext().commands().register(command.getName(), builder -> {
+            builder.namespace("huskhomes")
+                    .permission(command.getPermission())
+                    .executes(this::execute);
+            final List<String> aliases = command.getAliases().stream()
+                    .filter(alias -> !alias.equals(command.getName()))
+                    .toList();
+            if (!aliases.isEmpty()) {
+                builder.aliases(aliases);
+            }
+            if (!command.getRawUsage().isBlank()) {
+                builder.argument("arguments", Arguments.greedyString(), argument -> {
+                    argument.executes(this::execute);
+                    if (command instanceof TabCompletable) {
+                        argument.suggests(this::suggest);
+                    }
+                });
+            }
+        });
+    }
+
+    private void execute(@NotNull CommandContext context) {
+        command.onExecuted(resolve(context.sender()), context.args().toArray(String[]::new));
+    }
+
+    @NotNull
+    private List<String> suggest(@NotNull CommandContext context) {
+        if (!(command instanceof TabCompletable completable)) {
+            return List.of();
+        }
+        return completable.getSuggestions(resolve(context.sender()), context.args().toArray(String[]::new));
+    }
+
+    @NotNull
+    private CommandUser resolve(@NotNull CommandSender sender) {
+        return sender instanceof Player player ? plugin.getOnlineUser(player) : ConsoleUser.wrap(sender);
+    }
+}

--- a/fand/src/main/java/net/william278/huskhomes/event/FandEventDispatcher.java
+++ b/fand/src/main/java/net/william278/huskhomes/event/FandEventDispatcher.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes.event;
+
+import net.william278.huskhomes.FandHuskHomes;
+import net.william278.huskhomes.position.Home;
+import net.william278.huskhomes.position.Position;
+import net.william278.huskhomes.position.Warp;
+import net.william278.huskhomes.teleport.Teleport;
+import net.william278.huskhomes.teleport.TeleportRequest;
+import net.william278.huskhomes.teleport.TimedTeleport;
+import net.william278.huskhomes.user.CommandUser;
+import net.william278.huskhomes.user.OnlineUser;
+import net.william278.huskhomes.user.User;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public interface FandEventDispatcher extends EventDispatcher {
+
+    @Override
+    default <T extends Event> boolean fireIsCancelled(@NotNull T event) {
+        getPlugin().getContext().events().fire(new FandHuskHomesEvent(event));
+        return event instanceof Cancellable cancellable && cancellable.isCancelled();
+    }
+
+    @Override
+    default ITeleportEvent getTeleportEvent(@NotNull Teleport teleport) {
+        return FandEvents.teleport(teleport);
+    }
+
+    @Override
+    default ITeleportWarmupEvent getTeleportWarmupEvent(@NotNull TimedTeleport teleport, int duration) {
+        return FandEvents.teleportWarmup(teleport, duration);
+    }
+
+    @Override
+    default ITeleportWarmupCancelledEvent getTeleportWarmupCancelledEvent(@NotNull TimedTeleport teleport,
+                                                                          int duration, int cancelledAfter,
+                                                                          @NotNull ITeleportWarmupCancelledEvent.CancelReason reason) {
+        return FandEvents.teleportWarmupCancelled(teleport, duration, cancelledAfter, reason);
+    }
+
+    @Override
+    default ISendTeleportRequestEvent getSendTeleportRequestEvent(@NotNull OnlineUser sender,
+                                                                  @NotNull TeleportRequest request) {
+        return FandEvents.sendRequest(sender, request);
+    }
+
+    @Override
+    default IReceiveTeleportRequestEvent getReceiveTeleportRequestEvent(@NotNull OnlineUser recipient,
+                                                                        @NotNull TeleportRequest request) {
+        return FandEvents.receiveRequest(recipient, request);
+    }
+
+    @Override
+    default IReplyTeleportRequestEvent getReplyTeleportRequestEvent(@NotNull OnlineUser recipient,
+                                                                    @NotNull TeleportRequest request) {
+        return FandEvents.replyRequest(recipient, request);
+    }
+
+    @Override
+    default IHomeCreateEvent getHomeCreateEvent(@NotNull User owner, @NotNull String name,
+                                                @NotNull Position position, @NotNull CommandUser creator) {
+        return FandEvents.homeCreate(owner, name, position, creator);
+    }
+
+    @Override
+    default IHomeEditEvent getHomeEditEvent(@NotNull Home home, @NotNull Home original,
+                                            @NotNull CommandUser editor) {
+        return FandEvents.homeEdit(home, original, editor);
+    }
+
+    @Override
+    default IHomeDeleteEvent getHomeDeleteEvent(@NotNull Home home, @NotNull CommandUser deleter) {
+        return FandEvents.homeDelete(home, deleter);
+    }
+
+    @Override
+    default IWarpCreateEvent getWarpCreateEvent(@NotNull String name, @NotNull Position position,
+                                                @NotNull CommandUser creator) {
+        return FandEvents.warpCreate(name, position, creator);
+    }
+
+    @Override
+    default IWarpEditEvent getWarpEditEvent(@NotNull Warp warp, @NotNull Warp original,
+                                            @NotNull CommandUser editor) {
+        return FandEvents.warpEdit(warp, original, editor);
+    }
+
+    @Override
+    default IWarpDeleteEvent getWarpDeleteEvent(@NotNull Warp warp, @NotNull CommandUser deleter) {
+        return FandEvents.warpDelete(warp, deleter);
+    }
+
+    @Override
+    default IHomeListEvent getViewHomeListEvent(@NotNull List<Home> homes, @NotNull CommandUser viewer,
+                                                boolean publicHomeList) {
+        return FandEvents.homeList(homes, viewer, publicHomeList);
+    }
+
+    @Override
+    default IWarpListEvent getViewWarpListEvent(@NotNull List<Warp> warps, @NotNull CommandUser viewer) {
+        return FandEvents.warpList(warps, viewer);
+    }
+
+    @Override
+    default IDeleteAllHomesEvent getDeleteAllHomesEvent(@NotNull User user, @NotNull CommandUser deleter) {
+        return FandEvents.deleteAllHomes(user, deleter);
+    }
+
+    @Override
+    default IDeleteAllWarpsEvent getDeleteAllWarpsEvent(@NotNull CommandUser deleter) {
+        return FandEvents.deleteAllWarps(deleter);
+    }
+
+    @Override
+    @NotNull
+    FandHuskHomes getPlugin();
+}

--- a/fand/src/main/java/net/william278/huskhomes/event/FandEvents.java
+++ b/fand/src/main/java/net/william278/huskhomes/event/FandEvents.java
@@ -1,0 +1,355 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes.event;
+
+import net.william278.huskhomes.position.Home;
+import net.william278.huskhomes.position.Position;
+import net.william278.huskhomes.position.Warp;
+import net.william278.huskhomes.teleport.Teleport;
+import net.william278.huskhomes.teleport.TeleportRequest;
+import net.william278.huskhomes.teleport.TimedTeleport;
+import net.william278.huskhomes.user.CommandUser;
+import net.william278.huskhomes.user.OnlineUser;
+import net.william278.huskhomes.user.User;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Objects;
+
+final class FandEvents {
+
+    private FandEvents() {
+    }
+
+    static ITeleportEvent teleport(Teleport teleport) {
+        return switch (teleport.getType()) {
+            case BACK -> new BackTeleportEvent(teleport);
+            case RANDOM_TELEPORT -> new RandomTeleportEvent(teleport);
+            default -> new TeleportEvent(teleport);
+        };
+    }
+
+    static ITeleportWarmupEvent teleportWarmup(TimedTeleport teleport, int duration) {
+        return new WarmupEvent(teleport, duration);
+    }
+
+    static ITeleportWarmupCancelledEvent teleportWarmupCancelled(TimedTeleport teleport, int duration,
+                                                                  int cancelledAfter,
+                                                                  ITeleportWarmupCancelledEvent.CancelReason reason) {
+        return new WarmupCancelledEvent(teleport, duration, cancelledAfter, reason);
+    }
+
+    static ISendTeleportRequestEvent sendRequest(OnlineUser sender, TeleportRequest request) {
+        return new SendRequestEvent(sender, request);
+    }
+
+    static IReceiveTeleportRequestEvent receiveRequest(OnlineUser recipient, TeleportRequest request) {
+        return new ReceiveRequestEvent(recipient, request);
+    }
+
+    static IReplyTeleportRequestEvent replyRequest(OnlineUser recipient, TeleportRequest request) {
+        return new ReplyRequestEvent(recipient, request);
+    }
+
+    static IHomeCreateEvent homeCreate(User owner, String name, Position position, CommandUser creator) {
+        return new HomeCreateEvent(owner, name, position, creator);
+    }
+
+    static IHomeEditEvent homeEdit(Home home, Home original, CommandUser editor) {
+        return new HomeEditEvent(home, original, editor);
+    }
+
+    static IHomeDeleteEvent homeDelete(Home home, CommandUser deleter) {
+        return new HomeDeleteEvent(home, deleter);
+    }
+
+    static IWarpCreateEvent warpCreate(String name, Position position, CommandUser creator) {
+        return new WarpCreateEvent(name, position, creator);
+    }
+
+    static IWarpEditEvent warpEdit(Warp warp, Warp original, CommandUser editor) {
+        return new WarpEditEvent(warp, original, editor);
+    }
+
+    static IWarpDeleteEvent warpDelete(Warp warp, CommandUser deleter) {
+        return new WarpDeleteEvent(warp, deleter);
+    }
+
+    static IHomeListEvent homeList(List<Home> homes, CommandUser viewer, boolean publicHomes) {
+        return new HomeListEvent(homes, viewer, publicHomes);
+    }
+
+    static IWarpListEvent warpList(List<Warp> warps, CommandUser viewer) {
+        return new WarpListEvent(warps, viewer);
+    }
+
+    static IDeleteAllHomesEvent deleteAllHomes(User owner, CommandUser deleter) {
+        return new DeleteAllHomesEvent(owner, deleter);
+    }
+
+    static IDeleteAllWarpsEvent deleteAllWarps(CommandUser deleter) {
+        return new DeleteAllWarpsEvent(deleter);
+    }
+
+    private abstract static class CancellableEvent implements Cancellable {
+        private boolean cancelled;
+
+        @Override
+        public final void setCancelled(boolean cancelled) {
+            this.cancelled = cancelled;
+        }
+
+        @Override
+        public final boolean isCancelled() {
+            return cancelled;
+        }
+    }
+
+    private static class TeleportEvent extends CancellableEvent implements ITeleportEvent {
+        private final Teleport teleport;
+
+        private TeleportEvent(Teleport teleport) {
+            this.teleport = Objects.requireNonNull(teleport, "teleport");
+        }
+
+        @Override
+        public Teleport getTeleport() {
+            return teleport;
+        }
+    }
+
+    private static final class BackTeleportEvent extends TeleportEvent implements ITeleportBackEvent {
+        private BackTeleportEvent(Teleport teleport) {
+            super(teleport);
+        }
+
+        @Override
+        public Position getLastPosition() {
+            return (Position) getTeleport().getTarget();
+        }
+    }
+
+    private static final class RandomTeleportEvent extends TeleportEvent implements IRandomTeleportEvent {
+        private RandomTeleportEvent(Teleport teleport) {
+            super(teleport);
+        }
+
+        @Override
+        public Position getPosition() {
+            return (Position) getTeleport().getTarget();
+        }
+    }
+
+    private static final class WarmupEvent extends CancellableEvent implements ITeleportWarmupEvent {
+        private final TimedTeleport teleport;
+        private final int duration;
+
+        private WarmupEvent(TimedTeleport teleport, int duration) {
+            this.teleport = teleport;
+            this.duration = duration;
+        }
+
+        @Override
+        public int getWarmupDuration() {
+            return duration;
+        }
+
+        @Override
+        public TimedTeleport getTimedTeleport() {
+            return teleport;
+        }
+    }
+
+    private record WarmupCancelledEvent(TimedTeleport teleport, int duration, int cancelledAfter,
+                                        CancelReason reason) implements ITeleportWarmupCancelledEvent {
+        @Override
+        public int getWarmupDuration() {
+            return duration;
+        }
+
+        @Override
+        public TimedTeleport getTimedTeleport() {
+            return teleport;
+        }
+
+        @Override
+        public CancelReason getCancelReason() {
+            return reason;
+        }
+    }
+
+    private abstract static class RequestEvent extends CancellableEvent implements ITeleportRequestEvent {
+        private final TeleportRequest request;
+
+        private RequestEvent(TeleportRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public TeleportRequest getRequest() {
+            return request;
+        }
+    }
+
+    private static final class SendRequestEvent extends RequestEvent implements ISendTeleportRequestEvent {
+        private final OnlineUser sender;
+
+        private SendRequestEvent(OnlineUser sender, TeleportRequest request) {
+            super(request);
+            this.sender = sender;
+        }
+
+        @Override
+        public OnlineUser getSender() {
+            return sender;
+        }
+    }
+
+    private static final class ReceiveRequestEvent extends RequestEvent implements IReceiveTeleportRequestEvent {
+        private final OnlineUser recipient;
+
+        private ReceiveRequestEvent(OnlineUser recipient, TeleportRequest request) {
+            super(request);
+            this.recipient = recipient;
+        }
+
+        @Override
+        public OnlineUser getRecipient() {
+            return recipient;
+        }
+    }
+
+    private static final class ReplyRequestEvent extends RequestEvent implements IReplyTeleportRequestEvent {
+        private final OnlineUser recipient;
+
+        private ReplyRequestEvent(OnlineUser recipient, TeleportRequest request) {
+            super(request);
+            this.recipient = recipient;
+        }
+
+        @Override
+        public OnlineUser getRecipient() {
+            return recipient;
+        }
+    }
+
+    private static final class HomeCreateEvent extends CancellableEvent implements IHomeCreateEvent {
+        private final User owner;
+        private final CommandUser creator;
+        private String name;
+        private Position position;
+
+        private HomeCreateEvent(User owner, String name, Position position, CommandUser creator) {
+            this.owner = owner;
+            this.name = name;
+            this.position = position;
+            this.creator = creator;
+        }
+
+        @Override public User getOwner() { return owner; }
+        @Override public String getName() { return name; }
+        @Override public void setName(@NotNull String name) { this.name = name; }
+        @Override public Position getPosition() { return position; }
+        @Override public void setPosition(@NotNull Position position) { this.position = position; }
+        @Override public CommandUser getCreator() { return creator; }
+    }
+
+    private static final class HomeEditEvent extends CancellableEvent implements IHomeEditEvent {
+        private final Home home;
+        private final Home original;
+        private final CommandUser editor;
+
+        private HomeEditEvent(Home home, Home original, CommandUser editor) {
+            this.home = home;
+            this.original = original;
+            this.editor = editor;
+        }
+
+        @Override public Home getHome() { return home; }
+        @Override public Home getOriginalHome() { return original; }
+        @Override public CommandUser getEditor() { return editor; }
+    }
+
+    private static final class HomeDeleteEvent extends CancellableEvent implements IHomeDeleteEvent {
+        private final Home home;
+        private final CommandUser deleter;
+        private HomeDeleteEvent(Home home, CommandUser deleter) { this.home = home; this.deleter = deleter; }
+        @Override public Home getHome() { return home; }
+        @Override public CommandUser getDeleter() { return deleter; }
+    }
+
+    private static final class WarpCreateEvent extends CancellableEvent implements IWarpCreateEvent {
+        private final CommandUser creator;
+        private String name;
+        private Position position;
+        private WarpCreateEvent(String name, Position position, CommandUser creator) {
+            this.name = name; this.position = position; this.creator = creator;
+        }
+        @Override public String getName() { return name; }
+        @Override public void setName(@NotNull String name) { this.name = name; }
+        @Override public Position getPosition() { return position; }
+        @Override public void setPosition(@NotNull Position position) { this.position = position; }
+        @Override public CommandUser getCreator() { return creator; }
+    }
+
+    private static final class WarpEditEvent extends CancellableEvent implements IWarpEditEvent {
+        private final Warp warp;
+        private final Warp original;
+        private final CommandUser editor;
+        private WarpEditEvent(Warp warp, Warp original, CommandUser editor) {
+            this.warp = warp; this.original = original; this.editor = editor;
+        }
+        @Override public Warp getWarp() { return warp; }
+        @Override public Warp getOriginalWarp() { return original; }
+        @Override public CommandUser getEditor() { return editor; }
+    }
+
+    private static final class WarpDeleteEvent extends CancellableEvent implements IWarpDeleteEvent {
+        private final Warp warp;
+        private final CommandUser deleter;
+        private WarpDeleteEvent(Warp warp, CommandUser deleter) { this.warp = warp; this.deleter = deleter; }
+        @Override public Warp getWarp() { return warp; }
+        @Override public CommandUser getDeleter() { return deleter; }
+    }
+
+    private static final class HomeListEvent extends CancellableEvent implements IHomeListEvent {
+        private final CommandUser viewer;
+        private final boolean publicHomes;
+        private List<Home> homes;
+        private HomeListEvent(List<Home> homes, CommandUser viewer, boolean publicHomes) {
+            this.homes = homes; this.viewer = viewer; this.publicHomes = publicHomes;
+        }
+        @Override public List<Home> getHomes() { return homes; }
+        @Override public void setHomes(@NotNull List<Home> homes) { this.homes = homes; }
+        @Override public CommandUser getListViewer() { return viewer; }
+        @Override public boolean getIsPublicHomeList() { return publicHomes; }
+    }
+
+    private static final class WarpListEvent extends CancellableEvent implements IWarpListEvent {
+        private final CommandUser viewer;
+        private List<Warp> warps;
+        private WarpListEvent(List<Warp> warps, CommandUser viewer) { this.warps = warps; this.viewer = viewer; }
+        @Override public List<Warp> getWarps() { return warps; }
+        @Override public void setWarps(@NotNull List<Warp> warps) { this.warps = warps; }
+        @Override public CommandUser getListViewer() { return viewer; }
+    }
+
+    private static final class DeleteAllHomesEvent extends CancellableEvent implements IDeleteAllHomesEvent {
+        private final User owner;
+        private final CommandUser deleter;
+        private DeleteAllHomesEvent(User owner, CommandUser deleter) { this.owner = owner; this.deleter = deleter; }
+        @Override public User getHomeOwner() { return owner; }
+        @Override public CommandUser getDeleter() { return deleter; }
+    }
+
+    private static final class DeleteAllWarpsEvent extends CancellableEvent implements IDeleteAllWarpsEvent {
+        private final CommandUser deleter;
+        private DeleteAllWarpsEvent(CommandUser deleter) { this.deleter = deleter; }
+        @Override public CommandUser getDeleter() { return deleter; }
+    }
+}

--- a/fand/src/main/java/net/william278/huskhomes/event/FandHuskHomesEvent.java
+++ b/fand/src/main/java/net/william278/huskhomes/event/FandHuskHomesEvent.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes.event;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+/**
+ * Fand event-bus envelope for a platform-neutral HuskHomes API event.
+ *
+ * @param event mutable HuskHomes event payload
+ */
+public record FandHuskHomesEvent(@NotNull Event event) implements io.fand.api.event.Event {
+
+    public FandHuskHomesEvent {
+        Objects.requireNonNull(event, "event");
+    }
+}

--- a/fand/src/main/java/net/william278/huskhomes/hook/FandHookProvider.java
+++ b/fand/src/main/java/net/william278/huskhomes/hook/FandHookProvider.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes.hook;
+
+import net.william278.huskhomes.FandHuskHomes;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public interface FandHookProvider extends HookProvider {
+
+    @Override
+    @NotNull
+    default List<Hook> getAvailableHooks() {
+        return List.of();
+    }
+
+    @Override
+    default boolean isDependencyAvailable(@NotNull String name) {
+        return getPlugin().server().plugins().isEnabled(name.toLowerCase());
+    }
+
+    @Override
+    @NotNull
+    FandHuskHomes getPlugin();
+}

--- a/fand/src/main/java/net/william278/huskhomes/listener/FandEventListener.java
+++ b/fand/src/main/java/net/william278/huskhomes/listener/FandEventListener.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes.listener;
+
+import io.fand.api.entity.Player;
+import io.fand.api.event.EventPriority;
+import io.fand.api.event.entity.EntityDamageEvent;
+import io.fand.api.event.player.PlayerDeathEvent;
+import io.fand.api.event.player.PlayerJoinEvent;
+import io.fand.api.event.player.PlayerQuitEvent;
+import io.fand.api.event.player.PlayerRespawnEvent;
+import io.fand.api.event.player.PlayerTeleportEvent;
+import net.william278.huskhomes.FandAdapter;
+import net.william278.huskhomes.FandHuskHomes;
+import org.jetbrains.annotations.NotNull;
+
+public final class FandEventListener extends EventListener {
+
+    public FandEventListener(@NotNull FandHuskHomes plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public void register() {
+        final var events = getPlugin().getContext().events();
+        events.subscribe(PlayerJoinEvent.class, event -> {
+            getPlugin().getOnlineUserMap().remove(event.player().uniqueId());
+            handlePlayerJoin(getPlugin().getOnlineUser(event.player()));
+        });
+        events.subscribe(PlayerQuitEvent.class, event -> handlePlayerLeave(getPlugin().getOnlineUser(event.player())));
+        events.subscribe(PlayerDeathEvent.class, event -> handlePlayerDeath(getPlugin().getOnlineUser(event.player())));
+        events.subscribe(PlayerRespawnEvent.class, event -> handlePlayerRespawn(getPlugin().getOnlineUser(event.player())));
+        events.subscribe(EntityDamageEvent.class, event -> {
+            if (!(event.entity() instanceof Player player)
+                    || event.amount() <= 0
+                    || !getPlugin().isWarmingUp(player.uniqueId())) {
+                return;
+            }
+            getPlugin().getWarmupDamagedUsers().add(player.uniqueId());
+        });
+        events.subscribe(PlayerTeleportEvent.class, EventPriority.OBSERVER, event -> {
+            if (!event.cancelled()) {
+                handlePlayerTeleport(
+                        getPlugin().getOnlineUser(event.player()),
+                        FandAdapter.adapt(event.from(), getPlugin().getServerName())
+                );
+            }
+        });
+    }
+
+    @Override
+    @NotNull
+    protected FandHuskHomes getPlugin() {
+        return (FandHuskHomes) super.getPlugin();
+    }
+}

--- a/fand/src/main/java/net/william278/huskhomes/user/FandUser.java
+++ b/fand/src/main/java/net/william278/huskhomes/user/FandUser.java
@@ -32,6 +32,7 @@ import java.util.logging.Level;
 public final class FandUser extends OnlineUser {
 
     private static final Key BUNGEE_CHANNEL = Key.key("bungeecord", "main");
+    private static final double MOVEMENT_THRESHOLD_SQUARED = 0.01D;
 
     private final Player player;
     private final String invulnerableTag;
@@ -131,10 +132,11 @@ public final class FandUser extends OnlineUser {
 
     @Override
     public boolean isMoving() {
-        final Vector3 velocity = player.velocity();
-        return Math.abs(velocity.x()) > 0.001D
-                || Math.abs(velocity.y()) > 0.001D
-                || Math.abs(velocity.z()) > 0.001D;
+        return isMoving(player.velocity());
+    }
+
+    static boolean isMoving(@NotNull Vector3 velocity) {
+        return velocity.lengthSquared() >= MOVEMENT_THRESHOLD_SQUARED;
     }
 
     @Override

--- a/fand/src/main/java/net/william278/huskhomes/user/FandUser.java
+++ b/fand/src/main/java/net/william278/huskhomes/user/FandUser.java
@@ -1,0 +1,176 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes.user;
+
+import io.fand.api.entity.Player;
+import io.fand.api.player.RespawnLocation;
+import io.fand.api.world.Vector3;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
+import net.william278.huskhomes.FandAdapter;
+import net.william278.huskhomes.FandHuskHomes;
+import net.william278.huskhomes.position.Location;
+import net.william278.huskhomes.position.Position;
+import net.william278.huskhomes.teleport.TeleportationException;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+
+public final class FandUser extends OnlineUser {
+
+    private static final Key BUNGEE_CHANNEL = Key.key("bungeecord", "main");
+
+    private final Player player;
+    private final String invulnerableTag;
+
+    private FandUser(@NotNull Player player, @NotNull FandHuskHomes plugin) {
+        super(player.uniqueId(), player.name(), plugin);
+        this.player = player;
+        this.invulnerableTag = plugin.getKey("invulnerable").asString();
+    }
+
+    @ApiStatus.Internal
+    @NotNull
+    public static FandUser adapt(@NotNull Player player, @NotNull FandHuskHomes plugin) {
+        return new FandUser(player, plugin);
+    }
+
+    @NotNull
+    public Player getPlayer() {
+        return player;
+    }
+
+    @Override
+    public Position getPosition() {
+        return FandAdapter.adapt(player, plugin.getServerName());
+    }
+
+    @Override
+    public Optional<Position> getBedSpawnPosition() {
+        return player.respawnLocation()
+                .map(RespawnLocation::location)
+                .map(location -> FandAdapter.adapt(location, plugin.getServerName()));
+    }
+
+    @Override
+    public double getHealth() {
+        return player.health();
+    }
+
+    @Override
+    public boolean isPermissionSet(@NotNull String permission) {
+        return player.permissionValue(permission).isPresent();
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull String node) {
+        return player.can(node);
+    }
+
+    @Override
+    @NotNull
+    public Map<String, Boolean> getPermissions() {
+        final Map<String, Boolean> values = new LinkedHashMap<>();
+        ((FandHuskHomes) plugin).getPermissions().keySet()
+                .forEach(permission -> values.put(permission, player.can(permission)));
+        return values;
+    }
+
+    @Override
+    @NotNull
+    protected List<Integer> getNumericalPermissions(@NotNull String nodePrefix) {
+        final List<Integer> permissions = new ArrayList<>();
+        for (int value = 0; value < 100; value++) {
+            if (hasPermission(nodePrefix + value)) {
+                permissions.add(value);
+            }
+        }
+        permissions.sort(Collections.reverseOrder());
+        return List.copyOf(permissions);
+    }
+
+    @Override
+    @NotNull
+    public Audience getAudience() {
+        return player;
+    }
+
+    @Override
+    public CompletableFuture<Void> dismount() {
+        return player.dismount().thenRun(player::ejectPassengers);
+    }
+
+    @Override
+    public void teleportLocally(@NotNull Location location, boolean async) throws TeleportationException {
+        final io.fand.api.world.Location destination = FandAdapter.adapt(location, ((FandHuskHomes) plugin).server())
+                .orElseThrow(() -> new TeleportationException(TeleportationException.Type.WORLD_NOT_FOUND, plugin));
+        player.teleport(destination).whenComplete((success, failure) -> {
+            if (failure != null) {
+                plugin.log(Level.WARNING, "Failed to teleport player " + getName(), failure);
+            }
+        });
+    }
+
+    @Override
+    public void sendPluginMessage(byte[] message) {
+        ((FandHuskHomes) plugin).getContext().pluginMessaging().send(player, BUNGEE_CHANNEL, message);
+    }
+
+    @Override
+    public boolean isMoving() {
+        final Vector3 velocity = player.velocity();
+        return Math.abs(velocity.x()) > 0.001D
+                || Math.abs(velocity.y()) > 0.001D
+                || Math.abs(velocity.z()) > 0.001D;
+    }
+
+    @Override
+    public boolean isVanished() {
+        return false;
+    }
+
+    @Override
+    public boolean hasInvulnerability() {
+        return markedAsInvulnerable || player.scoreboardTags().contains(invulnerableTag);
+    }
+
+    @Override
+    public void handleInvulnerability() {
+        final long invulnerableTicks = 20L * plugin.getSettings().getGeneral().getTeleportInvulnerabilityTime();
+        if (invulnerableTicks <= 0 || player.invulnerable()) {
+            return;
+        }
+        markedAsInvulnerable = true;
+        player.addScoreboardTag(invulnerableTag);
+        player.setInvulnerable(true);
+        plugin.runSyncDelayed(this::removeInvulnerabilityIfPermitted, this, invulnerableTicks);
+    }
+
+    @Override
+    public void removeInvulnerabilityIfPermitted() {
+        if (!hasInvulnerability()) {
+            return;
+        }
+        player.setInvulnerable(false);
+        player.removeScoreboardTag(invulnerableTag);
+        markedAsInvulnerable = false;
+    }
+
+    @Override
+    public boolean isValid() {
+        return player.online();
+    }
+}

--- a/fand/src/main/java/net/william278/huskhomes/user/FandUserProvider.java
+++ b/fand/src/main/java/net/william278/huskhomes/user/FandUserProvider.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes.user;
+
+import io.fand.api.entity.Player;
+import net.william278.huskhomes.FandHuskHomes;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public interface FandUserProvider extends UserProvider {
+
+    @Override
+    @NotNull
+    default OnlineUser getOnlineUser(@NotNull UUID uuid) {
+        return getOnlineUser(getPlugin().server().player(uuid)
+                .orElseThrow(() -> new IllegalArgumentException("Player is not online")));
+    }
+
+    @NotNull
+    default FandUser getOnlineUser(@NotNull Player player) {
+        final OnlineUser cached = getOnlineUserMap().get(player.uniqueId());
+        if (cached instanceof FandUser user && user.getPlayer().online()) {
+            return user;
+        }
+        final FandUser user = FandUser.adapt(player, getPlugin());
+        getOnlineUserMap().put(player.uniqueId(), user);
+        return user;
+    }
+
+    @Override
+    @NotNull
+    FandHuskHomes getPlugin();
+}

--- a/fand/src/main/java/net/william278/huskhomes/util/FandSavePositionProvider.java
+++ b/fand/src/main/java/net/william278/huskhomes/util/FandSavePositionProvider.java
@@ -1,0 +1,117 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes.util;
+
+import io.fand.api.block.Block;
+import io.fand.api.world.World;
+import net.william278.huskhomes.FandAdapter;
+import net.william278.huskhomes.FandHuskHomes;
+import net.william278.huskhomes.position.Location;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public interface FandSavePositionProvider extends SavePositionProvider {
+
+    @Override
+    default CompletableFuture<Optional<Location>> findSafeGroundLocation(@NotNull Location location) {
+        final CompletableFuture<Optional<Location>> result = new CompletableFuture<>();
+        final FandHuskHomes plugin = getPlugin();
+        plugin.getContext().scheduler().runMain(() -> {
+            try {
+                result.complete(FandAdapter.adapt(location.getWorld(), plugin.server())
+                        .filter(world -> world.worldBorder().contains(location.getX(), location.getZ()))
+                        .flatMap(world -> findSafeLocationNear(location, world)));
+            } catch (Throwable failure) {
+                result.completeExceptionally(failure);
+            }
+        });
+        return result;
+    }
+
+    private Optional<Location> findSafeLocationNear(@NotNull Location location, @NotNull World world) {
+        final int originX = (int) Math.floor(location.getX());
+        final int originZ = (int) Math.floor(location.getZ());
+        final int minY = configuredHeight(
+                getPlugin().getSettings().getRtp().getMinHeight(),
+                location.getWorld().getName(),
+                location.getWorld().getEnvironment() == net.william278.huskhomes.position.World.Environment.NETHER
+                        ? 0 : -64
+        );
+        final int maxY = configuredHeight(
+                getPlugin().getSettings().getRtp().getMaxHeight(),
+                location.getWorld().getName(),
+                location.getWorld().getEnvironment() == net.william278.huskhomes.position.World.Environment.NETHER
+                        ? 256 : 320
+        );
+
+        for (int xOffset = -SEARCH_RADIUS; xOffset <= SEARCH_RADIUS; xOffset++) {
+            for (int zOffset = -SEARCH_RADIUS; zOffset <= SEARCH_RADIUS; zOffset++) {
+                final int x = originX + xOffset;
+                final int z = originZ + zOffset;
+                final Optional<Integer> y = findSafeY(world, x, z, minY, maxY,
+                        location.getWorld().getEnvironment());
+                if (y.isPresent()) {
+                    return Optional.of(Location.at(x + 0.5D, y.get(), z + 0.5D, location.getWorld()));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Integer> findSafeY(@NotNull World world, int x, int z, int minY, int maxY,
+                                        @NotNull net.william278.huskhomes.position.World.Environment environment) {
+        if (environment == net.william278.huskhomes.position.World.Environment.NETHER) {
+            for (int y = minY + 1; y < maxY - 1; y++) {
+                if (isSafeLocation(world, x, y, z)) {
+                    return Optional.of(y);
+                }
+            }
+            return Optional.empty();
+        }
+
+        final int y = Math.max(minY + 1, Math.min(world.highestBlockYAt(x, z) + 1, maxY - 1));
+        return isSafeLocation(world, x, y, z) ? Optional.of(y) : Optional.empty();
+    }
+
+    private boolean isSafeLocation(@NotNull World world, int x, int y, int z) {
+        final Block ground = world.blockAt(x, y - 1, z);
+        final Block body = world.blockAt(x, y, z);
+        final Block head = world.blockAt(x, y + 1, z);
+        return ground.solid() && !ground.fluidBlock() && !ground.water() && !ground.lava()
+                && isBlockSafeForStanding(ground.type().key().asString())
+                && occupiable(body) && occupiable(head);
+    }
+
+    private boolean occupiable(@NotNull Block block) {
+        return (block.air() || block.replaceable())
+                && !block.water() && !block.lava()
+                && isBlockSafeForOccupation(block.type().key().asString());
+    }
+
+    private static int configuredHeight(@NotNull List<String> entries, @NotNull String worldName, int fallback) {
+        for (String entry : entries) {
+            final int separator = entry.lastIndexOf(':');
+            if (separator <= 0 || !entry.substring(0, separator).equals(worldName)) {
+                continue;
+            }
+            try {
+                return Integer.parseInt(entry.substring(separator + 1));
+            } catch (NumberFormatException ignored) {
+                return fallback;
+            }
+        }
+        return fallback;
+    }
+
+    @Override
+    @NotNull
+    FandHuskHomes getPlugin();
+}

--- a/fand/src/main/java/net/william278/huskhomes/util/FandTask.java
+++ b/fand/src/main/java/net/william278/huskhomes/util/FandTask.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes.util;
+
+import net.william278.huskhomes.FandHuskHomes;
+import net.william278.huskhomes.HuskHomes;
+import net.william278.huskhomes.user.OnlineUser;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+
+public interface FandTask extends Task {
+
+    final class Sync extends Task.Sync implements FandTask {
+
+        private io.fand.api.scheduler.Task task;
+
+        private Sync(@NotNull HuskHomes plugin, @NotNull Runnable runnable, long delayTicks) {
+            super(plugin, runnable, delayTicks);
+        }
+
+        @Override
+        public void run() {
+            final var scheduler = ((FandHuskHomes) plugin).getContext().scheduler();
+            task = delayTicks <= 0 ? scheduler.runMain(runnable) : scheduler.runMainAfterTicks(runnable, delayTicks);
+        }
+
+        @Override
+        public void cancel() {
+            if (task != null) {
+                task.cancel();
+            }
+            super.cancel();
+        }
+    }
+
+    final class Async extends Task.Async implements FandTask {
+
+        private io.fand.api.scheduler.Task task;
+
+        private Async(@NotNull HuskHomes plugin, @NotNull Runnable runnable, long delayTicks) {
+            super(plugin, runnable, delayTicks);
+        }
+
+        @Override
+        public void run() {
+            final var scheduler = ((FandHuskHomes) plugin).getContext().scheduler();
+            task = delayTicks <= 0
+                    ? scheduler.runAsync(runnable)
+                    : scheduler.runAsyncAfter(runnable, Duration.ofMillis(delayTicks * 50L));
+        }
+
+        @Override
+        public void cancel() {
+            if (task != null) {
+                task.cancel();
+            }
+            super.cancel();
+        }
+    }
+
+    final class Repeating extends Task.Repeating implements FandTask {
+
+        private io.fand.api.scheduler.Task task;
+
+        private Repeating(@NotNull HuskHomes plugin, @NotNull Runnable runnable, long repeatingTicks) {
+            super(plugin, runnable, repeatingTicks);
+        }
+
+        @Override
+        public void run() {
+            task = ((FandHuskHomes) plugin).getContext().scheduler()
+                    .runMainRepeatingTicks(runnable, 0L, repeatingTicks);
+        }
+
+        @Override
+        public void cancel() {
+            if (task != null) {
+                task.cancel();
+            }
+            super.cancel();
+        }
+    }
+
+    interface Supplier extends Task.Supplier {
+
+        @Override
+        @NotNull
+        default Task.Sync getSyncTask(@NotNull Runnable runnable, @Nullable OnlineUser user, long delayTicks) {
+            return new Sync(getPlugin(), runnable, delayTicks);
+        }
+
+        @Override
+        @NotNull
+        default Task.Async getAsyncTask(@NotNull Runnable runnable, long delayTicks) {
+            return new Async(getPlugin(), runnable, delayTicks);
+        }
+
+        @Override
+        @NotNull
+        default Task.Repeating getRepeatingTask(@NotNull Runnable runnable, long repeatingTicks) {
+            return new Repeating(getPlugin(), runnable, repeatingTicks);
+        }
+
+        @Override
+        default void cancelTasks() {
+        }
+    }
+}

--- a/fand/src/main/resources/fand-plugin.json
+++ b/fand/src/main/resources/fand-plugin.json
@@ -1,0 +1,14 @@
+{
+  "id": "huskhomes",
+  "version": "${version}",
+  "mainClass": "net.william278.huskhomes.FandHuskHomes",
+  "description": "${description}",
+  "website": "https://william278.net/project/huskhomes/",
+  "license": "Apache-2.0",
+  "apiVersion": "0.1.1",
+  "authors": ["William278"],
+  "depends": [],
+  "loadAfter": [],
+  "loadBefore": [],
+  "permissions": []
+}

--- a/fand/src/main/resources/libraries.json
+++ b/fand/src/main/resources/libraries.json
@@ -1,0 +1,30 @@
+{
+  "repositories": [
+    "https://repo.maven.apache.org/maven2/"
+  ],
+  "libraries": [
+    "org.xerial:sqlite-jdbc:${sqlite_driver_version}",
+    "com.mysql:mysql-connector-j:${mysql_driver_version}",
+    "org.mariadb.jdbc:mariadb-java-client:${mariadb_driver_version}",
+    "com.h2database:h2:${h2_driver_version}",
+    "org.postgresql:postgresql:${postgresql_driver_version}",
+    "redis.clients:jedis:${jedis_version}",
+    "org.apache.commons:commons-pool2:2.13.1"
+  ],
+  "sha256": {
+    "org.xerial:sqlite-jdbc:3.49.1.0": "5c8609d2ca341deb8c6f71778974b5ba4995c7d32d7c7c89d9392a3e72c39291",
+    "com.mysql:mysql-connector-j:9.3.0": "6c8e6692b521376d89bc5618c16cdeaf8c61854329f4fa25677ed08776c5bb76",
+    "com.google.protobuf:protobuf-java:4.29.0": "16901851ebe5e89fe88aaad3c26866373695bc2e30627bb8932847e2f5fc2e76",
+    "org.mariadb.jdbc:mariadb-java-client:3.5.3": "85c4ba2f221d0dfd439c26affbb294f784960763544263c65aba9c2c76858706",
+    "com.h2database:h2:2.3.232": "8dae62d22db8982c3dcb3826edb9c727c5d302063a67eef7d63d82de401f07d3",
+    "org.postgresql:postgresql:42.7.5": "69020b3bd20984543e817393f2e6c01a890ef2e37a77dd11d6d8508181d079ab",
+    "org.checkerframework:checker-qual:3.48.3": "443685b1b232803baaf803c15d6f5a425473c6f7b81c5f276dfcf93288e389a5",
+    "redis.clients:jedis:6.0.0": "649ab60fb183a0d41aee702c7e1093b0296c79d6c4a773768f6577a97864f245",
+    "org.slf4j:slf4j-api:1.7.36": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0",
+    "com.google.code.gson:gson:2.12.1": "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec",
+    "com.google.errorprone:error_prone_annotations:2.36.0": "77440e270b0bc9a249903c5a076c36a722c4886ca4f42675f2903a1c53ed61a5",
+    "org.apache.commons:commons-pool2:2.13.1": "f77a5060d6936a9144023584232f9de3f2248f1abfe156e9d31795f18770674f",
+    "org.json:json:20250107": "85d4c1ab192d3117fd02c7fff1ec0fe63ade45cf56def7fe950ef060cf06e99f",
+    "redis.clients.authentication:redis-authx-core:0.1.1-beta2": "cc56edb08b3df8562cddac108dca61907d21cc4ad04de05e9f5d1b01058390af"
+  }
+}

--- a/fand/src/test/java/net/william278/huskhomes/FandHuskHomesTest.java
+++ b/fand/src/test/java/net/william278/huskhomes/FandHuskHomesTest.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class FandHuskHomesTest {
+
+    @Test
+    void pluginEntrypointLinksAndHasNoArgConstructor() {
+        final Object plugin = assertDoesNotThrow(() ->
+                Class.forName("net.william278.huskhomes.FandHuskHomes").getConstructor().newInstance()
+        );
+        assertInstanceOf(FandHuskHomes.class, plugin);
+    }
+}

--- a/fand/src/test/java/net/william278/huskhomes/event/FandEventsTest.java
+++ b/fand/src/test/java/net/william278/huskhomes/event/FandEventsTest.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes.event;
+
+import net.kyori.adventure.audience.Audience;
+import net.william278.huskhomes.position.Position;
+import net.william278.huskhomes.position.World;
+import net.william278.huskhomes.user.CommandUser;
+import net.william278.huskhomes.user.User;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FandEventsTest {
+
+    @Test
+    void homeCreatePayloadRemainsMutableAndCancellableThroughEnvelope() {
+        final User owner = User.of(UUID.randomUUID(), "Owner");
+        final CommandUser creator = new TestCommandUser();
+        final Position original = Position.at(1, 2, 3, World.from("overworld"), "server");
+        final Position updated = Position.at(4, 5, 6, World.from("overworld"), "server");
+        final IHomeCreateEvent payload = FandEvents.homeCreate(owner, "home", original, creator);
+        final FandHuskHomesEvent event = new FandHuskHomesEvent(payload);
+
+        assertSame(payload, event.event());
+        assertFalse(payload.isCancelled());
+
+        payload.setName("updated");
+        payload.setPosition(updated);
+        payload.setCancelled(true);
+
+        assertEquals("updated", payload.getName());
+        assertSame(updated, payload.getPosition());
+        assertTrue(payload.isCancelled());
+    }
+
+    private static final class TestCommandUser implements CommandUser {
+        @Override
+        public @NotNull Audience getAudience() {
+            return Audience.empty();
+        }
+
+        @Override
+        public boolean isPermissionSet(@NotNull String permission) {
+            return true;
+        }
+
+        @Override
+        public boolean hasPermission(@NotNull String permission) {
+            return true;
+        }
+    }
+}

--- a/fand/src/test/java/net/william278/huskhomes/user/FandUserTest.java
+++ b/fand/src/test/java/net/william278/huskhomes/user/FandUserTest.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of HuskHomes, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ */
+
+package net.william278.huskhomes.user;
+
+import io.fand.api.world.Vector3;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FandUserTest {
+
+    @Test
+    void ignoresStationaryGroundVelocity() {
+        assertFalse(FandUser.isMoving(Vector3.ZERO));
+        assertFalse(FandUser.isMoving(new Vector3(0.0D, -0.0784D, 0.0D)));
+        assertFalse(FandUser.isMoving(new Vector3(0.099D, 0.0D, 0.0D)));
+    }
+
+    @Test
+    void detectsVelocityAtMovementThreshold() {
+        assertTrue(FandUser.isMoving(new Vector3(0.1D, 0.0D, 0.0D)));
+        assertTrue(FandUser.isMoving(new Vector3(0.08D, 0.06D, 0.0D)));
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,6 +25,9 @@ include(
         // Paper/Spigot
         'bukkit',
         'paper',
+
+        // Fand
+        'fand',
 )
 
 


### PR DESCRIPTION
## Summary

Adds first-class support for [Fand](https://github.com/FandMC/Fand) as a HuskHomes server platform.

The implementation keeps HuskHomes' shared business logic in the existing `common` module and provides a dedicated Fand adapter for commands, events, scheduling, players, teleportation, plugin messaging, and the public API.

## Changes

- Adds a new `fand` Gradle module and `HuskHomes-Fand` artifact
- Adds the Fand plugin entrypoint and platform lifecycle integration
- Adapts Fand players, worlds, positions, audiences, commands, and scheduled tasks
- Bridges HuskHomes API events through Fand's plugin event bus
- Adds Fand support for Bungee-compatible plugin messaging and cross-server features
- Declares database and Redis drivers through Fand's `libraries.json`
- Locks runtime libraries with SHA-256 checksums
- Adds Fand API publication support
- Updates setup, configuration, API, and event documentation
- Adds regression tests for plugin linkage, event mutability/cancellation, and teleport movement detection

## Testing

- `./gradlew :fand:test :fand:shadowJar --configure-on-demand`
- Verified that the Fand artifact builds successfully
- Smoke-tested plugin discovery, SQLite initialization, and plugin enablement on a Fand server
- Added coverage for stationary ground velocity and movement threshold handling

## Compatibility

- Requires Fand 0.7.4 or newer
- Requires Java 25
- Existing Bukkit and Fabric behavior is unchanged

I am happy to maintain the Fand platform adapter and address Fand-specific compatibility issues.