### PR TITLE
Support Minecraft 26.2 (Paper/Spigot) & fix Spigot startup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,9 @@ jobs:
             1.21.6
             1.21.8
             1.21.11
+            26.1.1
+            26.1.2
+            26.2
           java: 17
       - name: 'Fabric 1.21.1: Publish to Modrinth & CurseForge 🧵'
         uses: WiIIiam278/mc-publish@hangar

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -3,7 +3,7 @@ dependencies {
 
     implementation 'org.bstats:bstats-bukkit:3.2.1'
     implementation 'space.arim.morepaperlib:morepaperlib:0.4.4'
-    implementation 'net.kyori:adventure-platform-bukkit:4.4.1'
+    implementation "net.kyori:adventure-platform-bukkit:${adventure_platform_version}"
     implementation 'net.william278.toilet:toilet-bukkit:1.1.0'
 
     compileOnly 'org.spigotmc:spigot-api:1.17.1-R0.1-SNAPSHOT'
@@ -17,10 +17,10 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.42'
 
     testImplementation 'com.github.seeseemelk:MockBukkit-v1.17:1.13.0'
-    testImplementation 'net.kyori:adventure-platform-bukkit:4.4.1'
-    testImplementation 'net.kyori:adventure-api:4.26.1'
-    testImplementation 'net.kyori:adventure-text-minimessage:4.26.1'
-    testImplementation 'net.kyori:adventure-text-serializer-plain:4.26.1'
+    testImplementation "net.kyori:adventure-platform-bukkit:${adventure_platform_version}"
+    testImplementation "net.kyori:adventure-api:${adventure_version}"
+    testImplementation "net.kyori:adventure-text-minimessage:${adventure_version}"
+    testImplementation "net.kyori:adventure-text-serializer-plain:${adventure_version}"
     testImplementation 'org.apache.commons:commons-text:1.15.0'
     testImplementation "redis.clients:jedis:${jedis_version}"
     testImplementation "org.xerial:sqlite-jdbc:${sqlite_driver_version}"

--- a/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
@@ -76,6 +76,8 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Getter
 @NoArgsConstructor
@@ -214,10 +216,14 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes, BukkitTask
         return String.format("%s/%s", getServer().getName(), getServer().getVersion());
     }
 
+    // Match the numeric version prefix; Paper reports versions like "26.2.build.62-beta" since 26.1
+    private static final Pattern NUMERIC_VERSION = Pattern.compile("^\\d+(\\.\\d+)+");
+
     @Override
     @NotNull
     public Version getMinecraftVersion() {
-        return Version.fromString(getServer().getBukkitVersion());
+        final Matcher version = NUMERIC_VERSION.matcher(getServer().getBukkitVersion());
+        return Version.fromString(version.find() ? version.group() : getServer().getBukkitVersion());
     }
 
     @Override

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -20,3 +20,12 @@ libraries:
   - 'org.mariadb.jdbc:mariadb-java-client:${mariadb_driver_version}'
   - 'org.xerial:sqlite-jdbc:${sqlite_driver_version}'
   - 'com.h2database:h2:${h2_driver_version}'
+  # Adventure is not bundled in the jar (Paper provides it natively - see paper/build.gradle)
+  - 'net.kyori:adventure-text-minimessage:${adventure_version}'
+  - 'net.kyori:adventure-text-serializer-plain:${adventure_version}'
+  - 'net.kyori:adventure-text-serializer-legacy:${adventure_version}'
+  - 'net.kyori:adventure-text-serializer-gson:${adventure_version}'
+  - 'net.kyori:adventure-text-serializer-gson-legacy-impl:${adventure_version}'
+  - 'net.kyori:adventure-text-serializer-json-legacy-impl:${adventure_version}'
+  - 'net.kyori:adventure-nbt:${adventure_version}'
+  - 'net.kyori:adventure-text-serializer-bungeecord:${adventure_platform_version}'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api 'net.kyori:adventure-text-minimessage:4.26.1'
+    api "net.kyori:adventure-text-minimessage:${adventure_version}"
     api 'net.william278:desertwell:2.0.7'
     api 'commons-io:commons-io:2.21.0'
     api 'org.apache.commons:commons-text:1.15.0'
@@ -18,8 +18,8 @@ dependencies {
 
     compileOnly 'org.jetbrains:annotations:26.1.0'
     compileOnly 'com.google.guava:guava:33.5.0-jre'
-    compileOnly 'net.kyori:adventure-api:4.26.1'
-    compileOnly 'net.kyori:adventure-platform-api:4.4.1'
+    compileOnly "net.kyori:adventure-api:${adventure_version}"
+    compileOnly "net.kyori:adventure-platform-api:${adventure_platform_version}"
     compileOnly 'com.github.plan-player-analytics:Plan:5.6.2883'
     compileOnly 'com.github.BlueMap-Minecraft:BlueMapAPI:2.6.0'
     compileOnly 'us.dynmap:DynmapCoreAPI:3.4'

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,8 @@ mariadb_driver_version=3.5.3
 sqlite_driver_version=3.49.1.0
 h2_driver_version=2.3.232
 postgresql_driver_version=42.7.5
+adventure_version=4.26.1
+adventure_platform_version=4.4.1
 
 # Fabric settings
 loom.ignoreDependencyLoomVersionValidation=true

--- a/paper/build.gradle
+++ b/paper/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'xyz.jpenilla.run-paper' version '2.3.1'
+    id 'xyz.jpenilla.run-paper' version '3.0.2'
 }
 
 dependencies {
@@ -59,7 +59,7 @@ shadowJar {
 
 tasks {
     runServer {
-        minecraftVersion('1.21.4')
+        minecraftVersion('26.2')
 
         downloadPlugins {
             url("https://download.luckperms.net/1571/bukkit/loader/LuckPerms-Bukkit-5.4.154.jar")


### PR DESCRIPTION
**Fixes Spigot startup (broken since #998)** 

the Paper jar excludes adventure-api and MiniMessage (Paper provides them natively), but nothing supplied them on pure Spigot,so the plugin failed to load with `NoClassDefFoundError`. They are now resolved at runtime through the Spigot library loader (`plugin.yml` → `libraries:`), pinned via `adventure_version` / `adventure_platform_version``gradle.properties` alongside the other runtime libraries. Paper/Folia are unaffected, as `paper-plugin.yml` takes precedence there. Fixes #1005.

**Supports Minecraft 26.2 on Paper & Spigot:**

- `BukkitHuskHomes#getMinecraftVersion` now parses only the numeric prefix of the Bukkit version string. Paper reports versions like `26.2.build.62-beta` since 26.1, which made DesertWell's `Version#parse` throw `NumberFormatException: For input string: "build"` (breaking `/huskhomes status`).
- Bumped run-paper 2.3.1 → 3.0.2 (older versions use the retired download API and cannot fetch 26.2 builds); `runServer` now targets 26.2.
- Added 26.1.1 / 26.1.2 / 26.2 to the release workflow's published game versions.

**Testing**

- Audited all Adventure call sites in `common`/`bukkit` against the Adventure 4.x → 5 migration guide: no removed APIs in use.
- `:common:test` and `:bukkit:test` pass.

**Notes**

- Folia is not validated — there are no upstream Folia builds for 26.2 yet.
- Fabric is intentionally untouched; Fabric 26.2 support is #999 (no conflicting files).