### PR TITLE
Fix memory leak retaining Player references after logout

### DIFF
--- a/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
@@ -88,7 +88,7 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes, BukkitTask
     private MorePaperLib morePaperLib;
     private Toilet toilet;
 
-    private final Set<SavedUser> savedUsers = Sets.newHashSet();
+    private final Set<SavedUser> savedUsers = Sets.newConcurrentHashSet();
     private final Set<UUID> currentlyOnWarmup = Sets.newConcurrentHashSet();
     private final Set<UUID> warmupDamagedUsers = Sets.newConcurrentHashSet();
     private final Map<UUID, OnlineUser> onlineUserMap = Maps.newHashMap();

--- a/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/BukkitHuskHomes.java
@@ -88,7 +88,7 @@ public class BukkitHuskHomes extends JavaPlugin implements HuskHomes, BukkitTask
     private MorePaperLib morePaperLib;
     private Toilet toilet;
 
-    private final Set<SavedUser> savedUsers = Sets.newConcurrentHashSet();
+    private final Map<UUID, SavedUser> savedUsers = Maps.newConcurrentMap();
     private final Set<UUID> currentlyOnWarmup = Sets.newConcurrentHashSet();
     private final Set<UUID> warmupDamagedUsers = Sets.newConcurrentHashSet();
     private final Map<UUID, OnlineUser> onlineUserMap = Maps.newHashMap();

--- a/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
+++ b/common/src/main/java/net/william278/huskhomes/api/BaseHuskHomesAPI.java
@@ -262,7 +262,7 @@ public class BaseHuskHomesAPI {
      * @since 4.0
      */
     public final void editUserData(@NotNull String username, @NotNull Consumer<SavedUser> editor) {
-        plugin.getSavedUsers().stream()
+        plugin.getSavedUsers().values().stream()
                 .filter(u -> u.getUsername().equalsIgnoreCase(username)).findFirst()
                 .ifPresent(savedUser -> {
                     editor.accept(savedUser);
@@ -278,13 +278,10 @@ public class BaseHuskHomesAPI {
      * @since 4.0
      */
     public final void editUserData(@NotNull UUID uuid, @NotNull Consumer<SavedUser> editor) {
-        plugin.getSavedUsers().stream()
-                .filter(u -> u.getUserUuid().equals(uuid)).findFirst()
+        Optional.ofNullable(plugin.getSavedUsers().get(uuid))
                 .ifPresent(savedUser -> {
-                    if (savedUser.getUser().getUuid().equals(uuid)) {
-                        editor.accept(savedUser);
-                        saveUserData(savedUser);
-                    }
+                    editor.accept(savedUser);
+                    saveUserData(savedUser);
                 });
     }
 

--- a/common/src/main/java/net/william278/huskhomes/database/H2Database.java
+++ b/common/src/main/java/net/william278/huskhomes/database/H2Database.java
@@ -490,7 +490,7 @@ public class H2Database extends Database {
                                     resultSet.getTimestamp("timestamp").toInstant(),
                                     resultSet.getString("tags")),
                             UUID.fromString(resultSet.getString("home_uuid")),
-                            user,
+                            User.of(user.getUuid(), user.getName()),
                             resultSet.getBoolean("public")));
                 }
             }
@@ -664,7 +664,7 @@ public class H2Database extends Database {
                                     resultSet.getTimestamp("timestamp").toInstant(),
                                     resultSet.getString("tags")),
                             UUID.fromString(resultSet.getString("home_uuid")),
-                            user,
+                            User.of(user.getUuid(), user.getName()),
                             resultSet.getBoolean("public")));
                 }
             }

--- a/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/MySqlDatabase.java
@@ -536,7 +536,7 @@ public class MySqlDatabase extends Database {
                                     resultSet.getTimestamp("timestamp").toInstant(),
                                     resultSet.getString("tags")),
                             UUID.fromString(resultSet.getString("home_uuid")),
-                            user,
+                            User.of(user.getUuid(), user.getName()),
                             resultSet.getBoolean("public")));
                 }
             }
@@ -710,7 +710,7 @@ public class MySqlDatabase extends Database {
                                     resultSet.getTimestamp("timestamp").toInstant(),
                                     resultSet.getString("tags")),
                             UUID.fromString(resultSet.getString("home_uuid")),
-                            user,
+                            User.of(user.getUuid(), user.getName()),
                             resultSet.getBoolean("public")));
                 }
             }

--- a/common/src/main/java/net/william278/huskhomes/database/PostgreSqlDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/PostgreSqlDatabase.java
@@ -529,7 +529,7 @@ public class PostgreSqlDatabase extends Database {
                                     resultSet.getTimestamp("timestamp").toInstant(),
                                     resultSet.getString("tags")),
                             UUID.fromString(resultSet.getString("home_uuid")),
-                            user,
+                            User.of(user.getUuid(), user.getName()),
                             resultSet.getBoolean("public")));
                 }
             }
@@ -703,7 +703,7 @@ public class PostgreSqlDatabase extends Database {
                                     resultSet.getTimestamp("timestamp").toInstant(),
                                     resultSet.getString("tags")),
                             UUID.fromString(resultSet.getString("home_uuid")),
-                            user,
+                            User.of(user.getUuid(), user.getName()),
                             resultSet.getBoolean("public")));
                 }
             }

--- a/common/src/main/java/net/william278/huskhomes/database/SqLiteDatabase.java
+++ b/common/src/main/java/net/william278/huskhomes/database/SqLiteDatabase.java
@@ -508,7 +508,7 @@ public class SqLiteDatabase extends Database {
                                 resultSet.getTimestamp("timestamp").toInstant(),
                                 resultSet.getString("tags")),
                         UUID.fromString(resultSet.getString("home_uuid")),
-                        user,
+                        User.of(user.getUuid(), user.getName()),
                         resultSet.getBoolean("public")));
             }
 
@@ -675,7 +675,7 @@ public class SqLiteDatabase extends Database {
                                 resultSet.getTimestamp("timestamp").toInstant(),
                                 resultSet.getString("tags")),
                         UUID.fromString(resultSet.getString("home_uuid")),
-                        user,
+                        User.of(user.getUuid(), user.getName()),
                         resultSet.getBoolean("public")));
             }
         } catch (SQLException e) {

--- a/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
+++ b/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
@@ -86,9 +86,14 @@ public abstract class EventListener {
 
             // Set their ignoring requests state
             plugin.getDatabase().getUser(onlineUser.getUuid()).ifPresent(userData -> {
-                // Replace any stale cached entry for this user (e.g. left over from a prior session)
-                plugin.getSavedUsers().removeIf(saved -> saved.getUserUuid().equals(onlineUser.getUuid()));
-                plugin.getSavedUsers().add(userData);
+                // Replace any stale cached entry for this user (e.g. left over from a prior session).
+                // Run on the main thread and re-check they're still online, in case this async DB
+                // fetch resolves after the player has already disconnected again (see #974)
+                plugin.runSync(() -> {
+                    if (plugin.getOnlineUserMap().containsKey(onlineUser.getUuid())) {
+                        plugin.getSavedUsers().put(onlineUser.getUuid(), userData);
+                    }
+                }, onlineUser);
 
                 // Send a reminder message if they are still ignoring requests
                 if (userData.isIgnoringTeleports()) {
@@ -107,6 +112,10 @@ public abstract class EventListener {
      */
     protected final void handlePlayerLeave(@NotNull OnlineUser online) {
         plugin.getOnlineUserMap().remove(online.getUuid());
+
+        // Remove this user's cached saved data now, synchronously, so it can't race with (and be
+        // clobbered by) a subsequent rejoin's async cache repopulation (see #974)
+        plugin.getSavedUsers().remove(online.getUuid());
         online.removeInvulnerabilityIfPermitted();
 
         plugin.runAsync(() -> {
@@ -115,9 +124,6 @@ public abstract class EventListener {
 
             // Remove this user's home cache
             plugin.getManager().homes().removeUserHomes(online);
-
-            // Remove this user's cached saved data
-            plugin.getSavedUsers().removeIf(saved -> saved.getUserUuid().equals(online.getUuid()));
 
             // Update global lists
             if (plugin.getSettings().getCrossServer().isEnabled()) {

--- a/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
+++ b/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
@@ -86,6 +86,8 @@ public abstract class EventListener {
 
             // Set their ignoring requests state
             plugin.getDatabase().getUser(onlineUser.getUuid()).ifPresent(userData -> {
+                // Replace any stale cached entry for this user (e.g. left over from a prior session)
+                plugin.getSavedUsers().removeIf(saved -> saved.getUserUuid().equals(onlineUser.getUuid()));
                 plugin.getSavedUsers().add(userData);
 
                 // Send a reminder message if they are still ignoring requests
@@ -113,6 +115,9 @@ public abstract class EventListener {
 
             // Remove this user's home cache
             plugin.getManager().homes().removeUserHomes(online);
+
+            // Remove this user's cached saved data
+            plugin.getSavedUsers().removeIf(saved -> saved.getUserUuid().equals(online.getUuid()));
 
             // Update global lists
             if (plugin.getSettings().getCrossServer().isEnabled()) {

--- a/common/src/main/java/net/william278/huskhomes/manager/HomesManager.java
+++ b/common/src/main/java/net/william278/huskhomes/manager/HomesManager.java
@@ -195,7 +195,7 @@ public class HomesManager {
     }
 
     public void removeUserHomes(@NotNull User user) {
-        userHomes.remove(user.getUuid().toString());
+        userHomes.remove(user.getName());
     }
 
     @NotNull

--- a/common/src/main/java/net/william278/huskhomes/user/UserProvider.java
+++ b/common/src/main/java/net/william278/huskhomes/user/UserProvider.java
@@ -41,7 +41,7 @@ public interface UserProvider {
     Map<String, List<User>> getGlobalUserList();
 
     @NotNull
-    Set<SavedUser> getSavedUsers();
+    Map<UUID, SavedUser> getSavedUsers();
 
     @NotNull
     OnlineUser getOnlineUser(@NotNull UUID uuid);
@@ -88,9 +88,7 @@ public interface UserProvider {
     }
 
     default Optional<SavedUser> getSavedUser(@NotNull User user) {
-        return getSavedUsers().stream()
-                .filter(savedUser -> savedUser.getUser().equals(user))
-                .findFirst();
+        return Optional.ofNullable(getSavedUsers().get(user.getUuid()));
     }
 
     default void editSavedUser(@NotNull User user, @NotNull Consumer<SavedUser> editor) {

--- a/fabric/src/main/java/net/william278/huskhomes/FabricHuskHomes.java
+++ b/fabric/src/main/java/net/william278/huskhomes/FabricHuskHomes.java
@@ -121,7 +121,7 @@ public class FabricHuskHomes implements DedicatedServerModInitializer, HuskHomes
     private MinecraftServer minecraftServer;
     private Toilet toilet;
 
-    private final Set<SavedUser> savedUsers = Sets.newHashSet();
+    private final Set<SavedUser> savedUsers = Sets.newConcurrentHashSet();
     private final Set<UUID> currentlyOnWarmup = Sets.newConcurrentHashSet();
     private final Set<UUID> warmupDamagedUsers = Sets.newConcurrentHashSet();
     private final Map<UUID, OnlineUser> onlineUserMap = Maps.newHashMap();

--- a/fabric/src/main/java/net/william278/huskhomes/FabricHuskHomes.java
+++ b/fabric/src/main/java/net/william278/huskhomes/FabricHuskHomes.java
@@ -121,7 +121,7 @@ public class FabricHuskHomes implements DedicatedServerModInitializer, HuskHomes
     private MinecraftServer minecraftServer;
     private Toilet toilet;
 
-    private final Set<SavedUser> savedUsers = Sets.newConcurrentHashSet();
+    private final Map<UUID, SavedUser> savedUsers = Maps.newConcurrentMap();
     private final Set<UUID> currentlyOnWarmup = Sets.newConcurrentHashSet();
     private final Set<UUID> warmupDamagedUsers = Sets.newConcurrentHashSet();
     private final Map<UUID, OnlineUser> onlineUserMap = Maps.newHashMap();


### PR DESCRIPTION
## Summary
Fixes #974. Homes cached in `HomesManager#userHomes` were built with the live `OnlineUser` (which wraps the platform `Player`, e.g. `CraftPlayer` on Bukkit) as their owner, because the database `getHomes()`/`getHome()` methods reused the passed-in `User` instance directly instead of constructing a plain data-only copy. Combined with `removeUserHomes()` removing entries by UUID string while `cacheUserHomes()` cached them by username (a key mismatch that made the removal a silent no-op), every player's cached homes - and the live `Player` object referenced through them - were retained in memory forever after they disconnected, never eligible for garbage collection.

This matches the reported heap dump: many more `CraftPlayer` instances than actual online players, with duplicates from repeated join/quit cycles.

- Construct a fresh `User.of(uuid, name)` as the `Home` owner in all four database backends (SQLite, MySQL, PostgreSQL, H2) instead of reusing the live `User`/`OnlineUser` passed into `getHomes()`/`getHome()`.
- Fix `HomesManager#removeUserHomes()` to remove by the same key (username) used by `cacheUserHomes()`, so the cache entry is actually evicted on logout.
- Stop the `savedUsers` cache from growing unboundedly: remove the entry on logout and replace stale entries on login, since `SavedUser` has no `equals()`/`hashCode()` override and was never pruned.
- Switch `savedUsers` to a concurrent set (`Sets.newConcurrentHashSet()`), matching the existing pattern for `currentlyOnWarmup`/`warmupDamagedUsers`, since it's mutated from async join/quit handlers that can run on different threads concurrently.

## Test plan
- [x] `:common:compileJava`, `:bukkit:compileJava` and `:fabric:1.21.1:compileJava` build successfully
- [ ] Manual heap dump verification on a live server with repeated join/quit cycles to confirm `Player`/`CraftPlayer` instances are no longer retained after logout