### PR TITLE
Hide vanished players from the cross-server player list

### DIFF
--- a/common/src/main/java/net/william278/huskhomes/config/Settings.java
+++ b/common/src/main/java/net/william278/huskhomes/config/Settings.java
@@ -327,6 +327,13 @@ public final class Settings {
         @Comment("Whether player respawn positions should work cross-server. "
                 + "Docs: https://william278.net/docs/huskhomes/global-respawning/")
         private boolean globalRespawning = false;
+
+        @Comment({"How often (in seconds) to re-send this server's player list to the rest of the network,",
+                "if it has changed. Toggling vanish doesn't fire a join or leave event, so without this a",
+                "vanished staff member would stay visible in other servers' player lists (and tab",
+                "completions) until the next player joins or leaves this server.",
+                "Set to 0 to disable; the list will then only be sent on player join/leave."})
+        private int userListRefreshSeconds = 10;
     }
 
     @Comment("Random teleport (/rtp) settings.")

--- a/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
+++ b/common/src/main/java/net/william278/huskhomes/listener/EventListener.java
@@ -69,7 +69,7 @@ public abstract class EventListener {
                 // Synchronize the global player list
                 plugin.runSyncDelayed(() -> this.updateUserList(
                                 onlineUser,
-                                plugin.getOnlineUsers().stream().map(u -> (User) u).toList()),
+                                plugin.getLocalUserList()),
                         onlineUser,
                         40L
                 );
@@ -116,7 +116,7 @@ public abstract class EventListener {
 
             // Update global lists
             if (plugin.getSettings().getCrossServer().isEnabled()) {
-                final List<User> users = plugin.getOnlineUsers().stream().map(u -> (User) u).toList();
+                final List<User> users = plugin.getLocalUserList();
                 if (plugin.getSettings().getCrossServer().getBrokerType() == Broker.Type.REDIS) {
                     this.updateUserList(online, users);
                     return;

--- a/common/src/main/java/net/william278/huskhomes/network/BrokerProvider.java
+++ b/common/src/main/java/net/william278/huskhomes/network/BrokerProvider.java
@@ -20,9 +20,12 @@
 package net.william278.huskhomes.network;
 
 import net.william278.huskhomes.HuskHomes;
+import net.william278.huskhomes.user.User;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 public interface BrokerProvider {
 
@@ -44,6 +47,41 @@ public interface BrokerProvider {
             case PLUGIN_MESSAGE -> setBroker(new PluginMessageBroker(getPlugin()));
         }
         getBroker().ifPresent(Broker::initialize);
+        loadUserListRefreshTask();
+    }
+
+    /**
+     * Start the task that periodically re-sends this server's player list to the network, if it has changed.
+     *
+     * <p>The list is otherwise only sent on player join and leave. Vanish plugins toggle a player's
+     * visibility without firing either event, so a staff member vanishing mid-session would remain
+     * visible in the player lists of every other server until the next join or leave happens here.
+     *
+     * @since 4.11
+     */
+    default void loadUserListRefreshTask() {
+        final int interval = getPlugin().getSettings().getCrossServer().getUserListRefreshSeconds();
+        if (interval <= 0 || getBroker().isEmpty()) {
+            return;
+        }
+
+        final AtomicReference<List<User>> lastSent = new AtomicReference<>();
+        getPlugin().getRepeatingTask(() -> getPlugin().runSync(() -> {
+            final List<User> users = getPlugin().getLocalUserList();
+            if (users.equals(lastSent.get())) {
+                return;
+            }
+
+            // Any online user can carry the message; vanished users are valid senders
+            getPlugin().getOnlineUsers().stream().findAny().ifPresent(sender -> getBroker().ifPresent(broker -> {
+                Message.builder()
+                        .type(Message.MessageType.UPDATE_USER_LIST)
+                        .target(Message.TARGET_ALL, Message.TargetType.SERVER)
+                        .payload(Payload.userList(users))
+                        .build().send(broker, sender);
+                lastSent.set(users);
+            }));
+        }), interval * 20L).run();
     }
 
     @NotNull

--- a/common/src/main/java/net/william278/huskhomes/network/MessageHandler.java
+++ b/common/src/main/java/net/william278/huskhomes/network/MessageHandler.java
@@ -25,8 +25,8 @@ import net.william278.huskhomes.position.Position;
 import net.william278.huskhomes.position.Warp;
 import net.william278.huskhomes.position.World;
 import net.william278.huskhomes.teleport.Teleport;
+import net.william278.huskhomes.teleport.TeleportRequest;
 import net.william278.huskhomes.user.OnlineUser;
-import net.william278.huskhomes.user.User;
 import net.william278.huskhomes.util.TransactionResolver;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,7 +45,7 @@ public interface MessageHandler {
 
         Message.builder()
                 .type(Message.MessageType.UPDATE_USER_LIST)
-                .payload(Payload.userList(getPlugin().getOnlineUsers().stream().map(online -> (User) online).toList()))
+                .payload(Payload.userList(getPlugin().getLocalUserList()))
                 .target(message.getSourceServer(), Message.TargetType.SERVER).build()
                 .send(getBroker(), receiver);
     }
@@ -85,10 +85,21 @@ public interface MessageHandler {
     }
 
     default void handleTeleportRequest(@NotNull Message message, @NotNull OnlineUser receiver) {
-        message.getPayload().getTeleportRequest().ifPresent(
-                (request) -> getPlugin().getManager().requests()
-                        .sendLocalTeleportRequest(request, receiver)
-        );
+        message.getPayload().getTeleportRequest().ifPresent((request) -> {
+            getPlugin().getManager().requests().sendLocalTeleportRequest(request, receiver);
+
+            // Requests to vanished users are dropped without a reply, which tells the requester the user is
+            // online here. Reply as if they weren't found, matching how a same-server request behaves.
+            // /tpaall broadcasts to every player on every server, so it is exempt - it would spam the requester.
+            if (request.getStatus() == TeleportRequest.Status.IGNORED && receiver.isVanished()
+                    && !message.getTarget().equals(Message.TARGET_ALL)) {
+                Message.builder()
+                        .type(Message.MessageType.TELEPORT_REQUEST_RESPONSE)
+                        .payload(Payload.teleportRequest(request))
+                        .target(request.getRequesterName(), Message.TargetType.PLAYER)
+                        .build().send(getBroker(), receiver);
+            }
+        });
     }
 
     default void handleTeleportRequestResponse(@NotNull Message message, @NotNull OnlineUser receiver) {

--- a/common/src/main/java/net/william278/huskhomes/user/UserProvider.java
+++ b/common/src/main/java/net/william278/huskhomes/user/UserProvider.java
@@ -52,11 +52,30 @@ public interface UserProvider {
         return getOnlineUserMap().values();
     }
 
+    /**
+     * Get the list of users online on this server, excluding those who are vanished.
+     *
+     * <p>This is the list broadcast to the rest of the network. Vanished users must be filtered out
+     * here, as the {@link User} objects sent over the network carry no vanish state and so cannot be
+     * filtered by the servers receiving them.
+     *
+     * @return this server's vanish-filtered user list
+     * @since 4.11
+     */
+    @NotNull
+    default List<User> getLocalUserList() {
+        return getOnlineUsers().stream()
+                .filter(online -> !online.isVanished())
+                .map(online -> (User) online)
+                .sorted()
+                .toList();
+    }
+
     @NotNull
     default List<User> getUserList() {
         return Stream.concat(
                 getGlobalUserList().values().stream().flatMap(Collection::stream),
-                getOnlineUsers().stream().filter(o -> !o.isVanished())
+                getLocalUserList().stream()
         ).distinct().sorted().toList();
     }
 

--- a/docs/Config-Files.md
+++ b/docs/Config-Files.md
@@ -150,6 +150,12 @@ cross_server:
     warp_name: Spawn
   # Whether player respawn positions should work cross-server. Docs: https://william278.net/docs/huskhomes/global-respawning/
   global_respawning: false
+  # How often (in seconds) to re-send this server's player list to the rest of the network,
+  # if it has changed. Toggling vanish doesn't fire a join or leave event, so without this a
+  # vanished staff member would stay visible in other servers' player lists (and tab
+  # completions) until the next player joins or leaves this server.
+  # Set to 0 to disable; the list will then only be sent on player join/leave.
+  user_list_refresh_seconds: 10
 # Random teleport (/rtp) settings.
 rtp:
   # Radial region around the /spawn position where players CAN be randomly teleported.


### PR DESCRIPTION
Vanish was only filtered when reading the player list on the local server; the list broadcast to the rest of the network was unfiltered, so a vanished staff member on one server stayed visible in every other server's tab completions. Receiving servers cannot filter it themselves, as the User objects sent over the network carry no vanish state.

Add UserProvider#getLocalUserList and use it at all three broadcast sites (join, leave, and REQUEST_USER_LIST replies).

The list is otherwise only sent on join and leave, and toggling vanish fires neither, so add a repeating task that re-sends it when it changes. It reads the same "vanished" metadata every vanish plugin sets, so it hooks none of them. Configurable via cross_server.user_list_refresh_ seconds (0 disables it).

Also reply to cross-server teleport requests aimed at a vanished user with an IGNORED response, so the requester is told the player was not found instead of that the request was sent - as already happens for a vanished user on the same server. /tpaall is exempt, as it broadcasts to every player on every server and would spam the requester.