### PR TITLE
refactor pr workflow

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -16,9 +16,12 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: 'Checkout for CI 🛎'
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: 'Set up JDKs 21 & 25 📦'
         uses: actions/setup-java@v5
         with:
@@ -30,10 +33,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v6.3.0
       - name: 'Build with Gradle 🏗️'
         run: ./gradlew build --build-cache
-      - name: 'Upload PR Build Artifacts 📤'
+      - name: 'Upload Unverified PR Build Artifacts 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: HuskHomes-PR-${{ github.event.pull_request.number }}-attempt-${{ github.run_attempt }}
+          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-attempt-${{ github.run_attempt }}
           path: |
             target/HuskHomes-Paper-*.jar
             target/HuskHomes-Fabric-*.jar

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [ 'master' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   checks: write
@@ -15,19 +19,31 @@ jobs:
     steps:
       - name: 'Checkout for CI 🛎'
         uses: actions/checkout@v6
-      - name: 'Set up JDK 21 📦'
+      - name: 'Set up JDKs 21 & 25 📦'
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: |
+            21
+            25
           distribution: 'temurin'
       - name: 'Set up Gradle 📦'
         uses: gradle/actions/setup-gradle@v6.3.0
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
       - name: 'Build with Gradle 🏗️'
-        run: ./gradlew test --build-cache
+        run: ./gradlew build --build-cache
+      - name: 'Upload PR Build Artifacts 📤'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: HuskHomes-PR-${{ github.event.pull_request.number }}-attempt-${{ github.run_attempt }}
+          path: |
+            target/HuskHomes-Paper-*.jar
+            target/HuskHomes-Fabric-*.jar
+            !target/*-sources.jar
+            !target/*-javadoc.jar
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
       - name: 'Publish Test Report 📊'
         uses: mikepenz/action-junit-report@v6
-        if: success() || failure() # Continue on failure
+        if: ${{ !cancelled() }}
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'


### PR DESCRIPTION
- cancels running workflow if a new commit happens (so the new commit will run the workflow)
- also installs java 25 (rn the runners alr have java 25, but can be an issue if they dont)
- uploads every pr (github already excludes first time contributors) to the action run
- skips tests if cancelled
- adds a timeout