### PR TITLE
[no ci] ci: seperate pr jars for easier downloads/testing

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -40,50 +40,46 @@ jobs:
         env:
           ARTIFACT_TAG: PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}
         run: |
-          shopt -s nullglob
-          artifacts=(target/HuskHomes-Paper-*.jar target/HuskHomes-Fabric-*.jar)
-          artifact_count=0
-
-          for artifact in "${artifacts[@]}"; do
-            filename="${artifact##*/}"
-            case "$filename" in
-              *-sources.jar|*-javadoc.jar)
-                continue
-                ;;
-              HuskHomes-Paper-*.jar)
-                loader="Paper"
-                ;;
-              HuskHomes-Fabric-*+mc.*.jar)
-                game_version="${filename##*+mc.}"
-                loader="Fabric-${game_version%.jar}"
-                ;;
-              *)
-                echo "Unable to determine loader for $filename" >&2
-                exit 1
-                ;;
-            esac
-
-            destination="target/UNVERIFIED-HuskHomes-${loader}-${ARTIFACT_TAG}.jar"
-            if [[ -e "$destination" ]]; then
-              echo "Duplicate artifact destination: $destination" >&2
-              exit 1
-            fi
-            mv -- "$artifact" "$destination"
-            artifact_count=$((artifact_count + 1))
-          done
-
-          if (( artifact_count == 0 )); then
-            echo "No distributable PR build artifacts were found" >&2
-            exit 1
-          fi
-      - name: 'Upload Unverified PR Build Artifacts 📤'
+          mv target/HuskHomes-Paper-*.jar "target/UNVERIFIED-HuskHomes-Paper-${ARTIFACT_TAG}.jar"
+          mv target/HuskHomes-Fabric-*+mc.1.21.1.jar "target/UNVERIFIED-HuskHomes-Fabric-1.21.1-${ARTIFACT_TAG}.jar"
+          mv target/HuskHomes-Fabric-*+mc.1.21.11.jar "target/UNVERIFIED-HuskHomes-Fabric-1.21.11-${ARTIFACT_TAG}.jar"
+          mv target/HuskHomes-Fabric-*+mc.26.1.2.jar "target/UNVERIFIED-HuskHomes-Fabric-26.1.2-${ARTIFACT_TAG}.jar"
+          mv target/HuskHomes-Fabric-*+mc.26.2.jar "target/UNVERIFIED-HuskHomes-Fabric-26.2-${ARTIFACT_TAG}.jar"
+      - name: 'Upload Unverified Paper PR Build Artifact 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}
-          path: target/UNVERIFIED-HuskHomes-*.jar
+          path: target/UNVERIFIED-HuskHomes-Paper-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
           if-no-files-found: error
           retention-days: 7
-          compression-level: 0
+          archive: false
+      - name: 'Upload Unverified Fabric 1.21.1 PR Build Artifact 📤'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          path: target/UNVERIFIED-HuskHomes-Fabric-1.21.1-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
+          if-no-files-found: error
+          retention-days: 7
+          archive: false
+      - name: 'Upload Unverified Fabric 1.21.11 PR Build Artifact 📤'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          path: target/UNVERIFIED-HuskHomes-Fabric-1.21.11-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
+          if-no-files-found: error
+          retention-days: 7
+          archive: false
+      - name: 'Upload Unverified Fabric 26.1.2 PR Build Artifact 📤'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          path: target/UNVERIFIED-HuskHomes-Fabric-26.1.2-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
+          if-no-files-found: error
+          retention-days: 7
+          archive: false
+      - name: 'Upload Unverified Fabric 26.2 PR Build Artifact 📤'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          path: target/UNVERIFIED-HuskHomes-Fabric-26.2-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
+          if-no-files-found: error
+          retention-days: 7
+          archive: false
       - name: 'Publish Test Report 📊'
         uses: mikepenz/action-junit-report@v6
         if: ${{ !cancelled() }}

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -40,46 +40,50 @@ jobs:
         env:
           ARTIFACT_TAG: PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}
         run: |
-          mv target/HuskHomes-Paper-*.jar "target/UNVERIFIED-HuskHomes-Paper-${ARTIFACT_TAG}.jar"
-          mv target/HuskHomes-Fabric-*+mc.1.21.1.jar "target/UNVERIFIED-HuskHomes-Fabric-1.21.1-${ARTIFACT_TAG}.jar"
-          mv target/HuskHomes-Fabric-*+mc.1.21.11.jar "target/UNVERIFIED-HuskHomes-Fabric-1.21.11-${ARTIFACT_TAG}.jar"
-          mv target/HuskHomes-Fabric-*+mc.26.1.2.jar "target/UNVERIFIED-HuskHomes-Fabric-26.1.2-${ARTIFACT_TAG}.jar"
-          mv target/HuskHomes-Fabric-*+mc.26.2.jar "target/UNVERIFIED-HuskHomes-Fabric-26.2-${ARTIFACT_TAG}.jar"
-      - name: 'Upload Unverified Paper PR Build Artifact 📤'
+          shopt -s nullglob
+          artifacts=(target/HuskHomes-Paper-*.jar target/HuskHomes-Fabric-*.jar)
+          artifact_count=0
+
+          for artifact in "${artifacts[@]}"; do
+            filename="${artifact##*/}"
+            case "$filename" in
+              *-sources.jar|*-javadoc.jar)
+                continue
+                ;;
+              HuskHomes-Paper-*.jar)
+                loader="Paper"
+                ;;
+              HuskHomes-Fabric-*+mc.*.jar)
+                game_version="${filename##*+mc.}"
+                loader="Fabric-${game_version%.jar}"
+                ;;
+              *)
+                echo "Unable to determine loader for $filename" >&2
+                exit 1
+                ;;
+            esac
+
+            destination="target/UNVERIFIED-HuskHomes-${loader}-${ARTIFACT_TAG}.jar"
+            if [[ -e "$destination" ]]; then
+              echo "Duplicate artifact destination: $destination" >&2
+              exit 1
+            fi
+            mv -- "$artifact" "$destination"
+            artifact_count=$((artifact_count + 1))
+          done
+
+          if (( artifact_count == 0 )); then
+            echo "No distributable PR build artifacts were found" >&2
+            exit 1
+          fi
+      - name: 'Upload Unverified PR Build Artifacts 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          path: target/UNVERIFIED-HuskHomes-Paper-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
+          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}
+          path: target/UNVERIFIED-HuskHomes-*.jar
           if-no-files-found: error
           retention-days: 7
-          archive: false
-      - name: 'Upload Unverified Fabric 1.21.1 PR Build Artifact 📤'
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          path: target/UNVERIFIED-HuskHomes-Fabric-1.21.1-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
-          if-no-files-found: error
-          retention-days: 7
-          archive: false
-      - name: 'Upload Unverified Fabric 1.21.11 PR Build Artifact 📤'
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          path: target/UNVERIFIED-HuskHomes-Fabric-1.21.11-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
-          if-no-files-found: error
-          retention-days: 7
-          archive: false
-      - name: 'Upload Unverified Fabric 26.1.2 PR Build Artifact 📤'
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          path: target/UNVERIFIED-HuskHomes-Fabric-26.1.2-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
-          if-no-files-found: error
-          retention-days: 7
-          archive: false
-      - name: 'Upload Unverified Fabric 26.2 PR Build Artifact 📤'
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          path: target/UNVERIFIED-HuskHomes-Fabric-26.2-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
-          if-no-files-found: error
-          retention-days: 7
-          archive: false
+          compression-level: 0
       - name: 'Publish Test Report 📊'
         uses: mikepenz/action-junit-report@v6
         if: ${{ !cancelled() }}

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -36,49 +36,50 @@ jobs:
       - name: 'Get Short Commit ID 📝'
         id: commit
         run: echo "short_id=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: 'Prepare Unverified PR Build Artifacts 📦'
+        env:
+          ARTIFACT_PREFIX: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}
+        run: |
+          mv target/HuskHomes-Paper-*.jar "target/${ARTIFACT_PREFIX}-Paper.jar"
+          mv target/HuskHomes-Fabric-*+mc.1.21.1.jar "target/${ARTIFACT_PREFIX}-Fabric-1.21.1.jar"
+          mv target/HuskHomes-Fabric-*+mc.1.21.11.jar "target/${ARTIFACT_PREFIX}-Fabric-1.21.11.jar"
+          mv target/HuskHomes-Fabric-*+mc.26.1.2.jar "target/${ARTIFACT_PREFIX}-Fabric-26.1.2.jar"
+          mv target/HuskHomes-Fabric-*+mc.26.2.jar "target/${ARTIFACT_PREFIX}-Fabric-26.2.jar"
       - name: 'Upload Unverified Paper PR Build Artifact 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Paper
-          path: |
-            target/HuskHomes-Paper-*.jar
-            !target/*-sources.jar
-            !target/*-javadoc.jar
+          path: target/UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Paper.jar
           if-no-files-found: error
           retention-days: 7
-          compression-level: 0
+          archive: false
       - name: 'Upload Unverified Fabric 1.21.1 PR Build Artifact 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-1.21.1
-          path: target/HuskHomes-Fabric-*+mc.1.21.1.jar
+          path: target/UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-1.21.1.jar
           if-no-files-found: error
           retention-days: 7
-          compression-level: 0
+          archive: false
       - name: 'Upload Unverified Fabric 1.21.11 PR Build Artifact 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-1.21.11
-          path: target/HuskHomes-Fabric-*+mc.1.21.11.jar
+          path: target/UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-1.21.11.jar
           if-no-files-found: error
           retention-days: 7
-          compression-level: 0
+          archive: false
       - name: 'Upload Unverified Fabric 26.1.2 PR Build Artifact 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-26.1.2
-          path: target/HuskHomes-Fabric-*+mc.26.1.2.jar
+          path: target/UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-26.1.2.jar
           if-no-files-found: error
           retention-days: 7
-          compression-level: 0
+          archive: false
       - name: 'Upload Unverified Fabric 26.2 PR Build Artifact 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-26.2
-          path: target/HuskHomes-Fabric-*+mc.26.2.jar
+          path: target/UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-26.2.jar
           if-no-files-found: error
           retention-days: 7
-          compression-level: 0
+          archive: false
       - name: 'Publish Test Report 📊'
         uses: mikepenz/action-junit-report@v6
         if: ${{ !cancelled() }}

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -38,45 +38,45 @@ jobs:
         run: echo "short_id=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: 'Prepare Unverified PR Build Artifacts 📦'
         env:
-          ARTIFACT_PREFIX: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}
+          ARTIFACT_TAG: PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}
         run: |
-          mv target/HuskHomes-Paper-*.jar "target/${ARTIFACT_PREFIX}-Paper.jar"
-          mv target/HuskHomes-Fabric-*+mc.1.21.1.jar "target/${ARTIFACT_PREFIX}-Fabric-1.21.1.jar"
-          mv target/HuskHomes-Fabric-*+mc.1.21.11.jar "target/${ARTIFACT_PREFIX}-Fabric-1.21.11.jar"
-          mv target/HuskHomes-Fabric-*+mc.26.1.2.jar "target/${ARTIFACT_PREFIX}-Fabric-26.1.2.jar"
-          mv target/HuskHomes-Fabric-*+mc.26.2.jar "target/${ARTIFACT_PREFIX}-Fabric-26.2.jar"
+          mv target/HuskHomes-Paper-*.jar "target/UNVERIFIED-HuskHomes-Paper-${ARTIFACT_TAG}.jar"
+          mv target/HuskHomes-Fabric-*+mc.1.21.1.jar "target/UNVERIFIED-HuskHomes-Fabric-1.21.1-${ARTIFACT_TAG}.jar"
+          mv target/HuskHomes-Fabric-*+mc.1.21.11.jar "target/UNVERIFIED-HuskHomes-Fabric-1.21.11-${ARTIFACT_TAG}.jar"
+          mv target/HuskHomes-Fabric-*+mc.26.1.2.jar "target/UNVERIFIED-HuskHomes-Fabric-26.1.2-${ARTIFACT_TAG}.jar"
+          mv target/HuskHomes-Fabric-*+mc.26.2.jar "target/UNVERIFIED-HuskHomes-Fabric-26.2-${ARTIFACT_TAG}.jar"
       - name: 'Upload Unverified Paper PR Build Artifact 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          path: target/UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Paper.jar
+          path: target/UNVERIFIED-HuskHomes-Paper-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
           if-no-files-found: error
           retention-days: 7
           archive: false
       - name: 'Upload Unverified Fabric 1.21.1 PR Build Artifact 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          path: target/UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-1.21.1.jar
+          path: target/UNVERIFIED-HuskHomes-Fabric-1.21.1-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
           if-no-files-found: error
           retention-days: 7
           archive: false
       - name: 'Upload Unverified Fabric 1.21.11 PR Build Artifact 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          path: target/UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-1.21.11.jar
+          path: target/UNVERIFIED-HuskHomes-Fabric-1.21.11-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
           if-no-files-found: error
           retention-days: 7
           archive: false
       - name: 'Upload Unverified Fabric 26.1.2 PR Build Artifact 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          path: target/UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-26.1.2.jar
+          path: target/UNVERIFIED-HuskHomes-Fabric-26.1.2-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
           if-no-files-found: error
           retention-days: 7
           archive: false
       - name: 'Upload Unverified Fabric 26.2 PR Build Artifact 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          path: target/UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-26.2.jar
+          path: target/UNVERIFIED-HuskHomes-Fabric-26.2-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}.jar
           if-no-files-found: error
           retention-days: 7
           archive: false

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -33,15 +33,49 @@ jobs:
         uses: gradle/actions/setup-gradle@v6.3.0
       - name: 'Build with Gradle 🏗️'
         run: ./gradlew build --build-cache
-      - name: 'Upload Unverified PR Build Artifacts 📤'
+      - name: 'Get Short Commit ID 📝'
+        id: commit
+        run: echo "short_id=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: 'Upload Unverified Paper PR Build Artifact 📤'
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-attempt-${{ github.run_attempt }}
+          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Paper
           path: |
             target/HuskHomes-Paper-*.jar
-            target/HuskHomes-Fabric-*.jar
             !target/*-sources.jar
             !target/*-javadoc.jar
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+      - name: 'Upload Unverified Fabric 1.21.1 PR Build Artifact 📤'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-1.21.1
+          path: target/HuskHomes-Fabric-*+mc.1.21.1.jar
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+      - name: 'Upload Unverified Fabric 1.21.11 PR Build Artifact 📤'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-1.21.11
+          path: target/HuskHomes-Fabric-*+mc.1.21.11.jar
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+      - name: 'Upload Unverified Fabric 26.1.2 PR Build Artifact 📤'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-26.1.2
+          path: target/HuskHomes-Fabric-*+mc.26.1.2.jar
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+      - name: 'Upload Unverified Fabric 26.2 PR Build Artifact 📤'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: UNVERIFIED-HuskHomes-PR-${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_id }}-Fabric-26.2
+          path: target/HuskHomes-Fabric-*+mc.26.2.jar
           if-no-files-found: error
           retention-days: 7
           compression-level: 0


### PR DESCRIPTION
- uploads the jars invidiually instead of all in a single zip
- adds the commit short hash to the jar for easiesr testing too (before was just using a commit count)