### PR TITLE
chore: reduce fabric jar size by 10% by upgrading sqlite driver

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ plugin_description=The powerful & intuitive homes, warps, and teleportation suit
 jedis_version=6.0.0
 mysql_driver_version=9.3.0
 mariadb_driver_version=3.5.3
-sqlite_driver_version=3.49.1.0
+sqlite_driver_version=3.53.1.0
 h2_driver_version=2.3.232
 postgresql_driver_version=42.7.5
 


### PR DESCRIPTION
latest driver versions no longer include android bindings by default, saves us about ~2.4mb.