### PR TITLE
Implement 1-based index placeholders for homes

### DIFF
--- a/bukkit/src/main/java/net/william278/huskhomes/hook/PlaceholderAPIHook.java
+++ b/bukkit/src/main/java/net/william278/huskhomes/hook/PlaceholderAPIHook.java
@@ -75,6 +75,22 @@ public class PlaceholderAPIHook extends Hook {
 
             // Return the requested data
             final OnlineUser player = plugin.getOnlineUser(offlinePlayer.getPlayer());
+
+            // Indexed placeholders: homes_<n> and public_homes_<n> (1-based)
+            if (params.matches("homes_\\d+")) {
+                return getIndexedHome(
+                        plugin.getManager().homes().getUserHomes().getOrDefault(player.getName(), List.of()),
+                        params.substring("homes_".length())
+                );
+            }
+
+            if (params.matches("public_homes_\\d+")) {
+                return getIndexedHome(
+                        plugin.getManager().homes().getPublicHomes().getOrDefault(player.getName(), List.of()),
+                        params.substring("public_homes_".length())
+                );
+            }
+
             return switch (params) {
                 case "homes_count" -> String.valueOf(plugin.getManager().homes()
                         .getUserHomes()
@@ -108,6 +124,25 @@ public class PlaceholderAPIHook extends Hook {
         @NotNull
         private String getBooleanValue(final boolean bool) {
             return bool ? PlaceholderAPIPlugin.booleanTrue() : PlaceholderAPIPlugin.booleanFalse();
+        }
+
+        /**
+         * Resolves a 1-based index into a home list, returning an empty string
+         * (not null) when out of range so unused tab-completer slots resolve
+         * to blank rather than leaving the literal placeholder unparsed.
+         */
+        @NotNull
+        private String getIndexedHome(@NotNull List<String> homes, @NotNull String indexStr) {
+            final int index;
+            try {
+                index = Integer.parseInt(indexStr);
+            } catch (NumberFormatException e) {
+                return "";
+            }
+            if (index < 1 || index > homes.size()) {
+                return "";
+            }
+            return homes.get(index - 1);
         }
 
     }

--- a/fabric/src/main/java/net/william278/huskhomes/hook/FabricPlaceholderAPIHook.java
+++ b/fabric/src/main/java/net/william278/huskhomes/hook/FabricPlaceholderAPIHook.java
@@ -53,6 +53,25 @@ public class FabricPlaceholderAPIHook extends Hook {
         //#endif
     }
 
+    /**
+     * Resolves a 1-based index into a home list, returning an empty string
+     * (not null) when out of range so unused/padded lookups resolve to
+     * blank rather than surfacing as an invalid placeholder.
+     */
+    @NotNull
+    private String getIndexedHome(@NotNull List<String> homes, @NotNull String indexStr) {
+        final int index;
+        try {
+            index = Integer.parseInt(indexStr);
+        } catch (NumberFormatException e) {
+            return "";
+        }
+        if (index < 1 || index > homes.size()) {
+            return "";
+        }
+        return homes.get(index - 1);
+    }
+
     @Override
     public void load() {
         //#if MC>=260102
@@ -74,6 +93,23 @@ public class FabricPlaceholderAPIHook extends Hook {
             //#else
             //$$ final OnlineUser player = ((FabricHuskHomes) plugin).getOnlineUser(ctx.player());
             //#endif
+
+            // Indexed placeholders: homes_<n> and public_homes_<n> (1-based)
+            if (arg.matches("homes_\\d+")) {
+                return PlaceholderResult.value(getIndexedHome(
+                        plugin.getManager().homes().getUserHomes()
+                                .getOrDefault(player.getName(), List.of()),
+                        arg.substring("homes_".length())
+                ));
+            }
+
+            if (arg.matches("public_homes_\\d+")) {
+                return PlaceholderResult.value(getIndexedHome(
+                        plugin.getManager().homes().getPublicHomes()
+                                .getOrDefault(player.getName(), List.of()),
+                        arg.substring("public_homes_".length())
+                ));
+            }
 
             final String response = switch (arg) {
                 case "homes_count" -> String.valueOf(plugin.getManager().homes()


### PR DESCRIPTION
Adds two new placeholders: `%huskhomes_homes_INDEX%` and `%huskhomes_public_homes_INDEX%` 
Partially implements #790 (doesn't implement RTP Cooldown Placeholder)

**Example of use (my server with custom commands):**

> MyCommand configuration:
<img width="324" height="356" alt="Image displaying MyCommand configuration" src="https://github.com/user-attachments/assets/c04bd8d5-6dd9-481f-a2cf-0f85c9876b6f" />

> In game tab-completion:
<img width="421" height="188" alt="Image displaying in game tab-completion" src="https://github.com/user-attachments/assets/29607191-8edf-4bfa-9841-1ac8ae3d22f2" />
